### PR TITLE
[codex] Allow bare unsafe await ignore calls

### DIFF
--- a/examples/lint/README.md
+++ b/examples/lint/README.md
@@ -30,13 +30,14 @@ The package `tsconfig.json` enables every Resultar rule as an error and opts int
   "noDiscardMode": "must-use",
   "noUnsafeAwait": "error",
   "noUnsafeAwaitMode": "all",
-  "noUnsafeAwaitIgnoreCalls": ["fastify.after"]
+  "noUnsafeAwaitIgnoreCalls": ["startServer", "fastify.after"]
 }
 ```
 
 That means the example covers both normal Resultar contexts and broader framework/bootstrap awaits.
-`fastify.after` is intentionally ignored to document the exact call-path escape hatch: `fastify.after`
-is allowed, while `fastify.ready`, `app.after`, and unrelated raw Promise awaits are still reported.
+`startServer` and `fastify.after` are intentionally ignored to document the exact call-path escape
+hatch: those exact calls are allowed, while `fastify.ready`, `app.after`, and unrelated raw Promise
+awaits are still reported.
 
 The smoke test verifies that every configured Resultar rule is reported through TypeScript 7 and that
 `src/resultar-clean.ts` has no diagnostics.

--- a/examples/lint/src/index.ts
+++ b/examples/lint/src/index.ts
@@ -130,6 +130,14 @@ const app = {
   after: async (): Promise<void> => undefined,
 };
 
+const startServer = async (): Promise<void> => undefined;
+
+// Bare function identifiers can also be ignored by exact source name. This call
+// is ignored because tsconfig.json configures "startServer".
+export const ignoredUnsafeAwaitFunctionExample = async (): Promise<void> => {
+  await startServer();
+};
+
 // noUnsafeAwaitIgnoreCalls is exact and source-name based. This call is ignored
 // by tsconfig.json because the configured path is "fastify.after".
 export const ignoredUnsafeAwaitCallExample = async (): Promise<void> => {

--- a/examples/lint/src/resultar-clean.ts
+++ b/examples/lint/src/resultar-clean.ts
@@ -45,6 +45,8 @@ interface FastifyLifecycle {
   after(): Promise<void>;
 }
 
+const startServer = async (): Promise<void> => undefined;
+
 const validateEmail = (email: string): StrictResult<string, InvalidEmailError> =>
   email.includes("@") ? ok(email) : InvalidEmailError.err({ email });
 
@@ -128,7 +130,13 @@ export const loadUserAtPromiseBoundary = async (id: string): Promise<User> =>
   await runPromise(loadUser(id));
 
 // noUnsafeAwaitIgnoreCalls: project-level escape hatches are exact. This is
-// clean because tsconfig.json configures ["fastify.after"].
+// clean because tsconfig.json configures "startServer".
+export const waitForServerStartup = async (): Promise<void> => {
+  await startServer();
+};
+
+// noUnsafeAwaitIgnoreCalls: project-level escape hatches are exact. This is
+// clean because tsconfig.json configures "fastify.after".
 export const waitForFastifyLifecycle = async (fastify: FastifyLifecycle): Promise<void> => {
   await fastify.after();
 };

--- a/examples/lint/tsconfig.json
+++ b/examples/lint/tsconfig.json
@@ -16,7 +16,7 @@
         "noTaggedErrorConstructorOverride": "error",
         "noTryCatchInSafeTry": "error",
         "noUnsafeAwait": "error",
-        "noUnsafeAwaitIgnoreCalls": ["fastify.after"],
+        "noUnsafeAwaitIgnoreCalls": ["startServer", "fastify.after"],
         "noUnsafeAwaitMode": "all",
         "noUselessRecovery": "error",
         "preferAndThen": "error",

--- a/packages/resultar-check/CHANGELOG.md
+++ b/packages/resultar-check/CHANGELOG.md
@@ -1,5 +1,12 @@
 # resultar-check
 
+## 1.1.1
+
+### Patch Changes
+
+- Allow `noUnsafeAwaitIgnoreCalls` entries to be bare function identifiers such as `startServer`,
+  in addition to dotted call paths such as `fastify.after`.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/resultar-check/README.md
+++ b/packages/resultar-check/README.md
@@ -185,8 +185,8 @@ allowed in async catch helpers such as `tryAsync`, `tryResultAsync`, `tryCatchAs
 registration.
 
 Use `noUnsafeAwaitIgnoreCalls` for framework lifecycle awaits that a project intentionally allows
-without wrapping in Resultar. Entries are exact dot-separated call paths; wildcards and type-aware
-matching are not supported:
+without wrapping in Resultar. Entries are exact source call paths; bare function identifiers and
+dotted property paths are supported, while wildcards and type-aware matching are not:
 
 ```json
 {
@@ -196,7 +196,7 @@ matching are not supported:
         "name": "resultar-check",
         "noUnsafeAwait": "error",
         "noUnsafeAwaitMode": "all",
-        "noUnsafeAwaitIgnoreCalls": ["fastify.after"]
+        "noUnsafeAwaitIgnoreCalls": ["startServer", "fastify.after"]
       }
     ]
   }

--- a/packages/resultar-check/jsr.json
+++ b/packages/resultar-check/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@inaiat/resultar-check",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "exports": "./src/diagnostics.ts",
   "publish": { "include": ["LICENSE", "README.md", "schema.json", "src/**/*.ts"] }

--- a/packages/resultar-check/package.json
+++ b/packages/resultar-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resultar-check",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "TypeScript 7 diagnostics for Resultar",
   "keywords": [
     "lint",

--- a/packages/resultar-check/schema.json
+++ b/packages/resultar-check/schema.json
@@ -72,7 +72,7 @@
           "type": "array",
           "items": { "$ref": "#/definitions/callPath" },
           "default": [],
-          "description": "Exact dot-separated call paths that noUnsafeAwait should ignore, such as fastify.after."
+          "description": "Exact source call paths that noUnsafeAwait should ignore, such as startServer or fastify.after."
         },
         "noUnsafeAwaitMode": {
           "type": "string",
@@ -125,7 +125,7 @@
     "resultarPluginName": { "type": "string", "enum": ["resultar-check", "resultar-lint"] },
     "callPath": {
       "type": "string",
-      "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*(\\.[A-Za-z_$][A-Za-z0-9_$]*)+$"
+      "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*(\\.[A-Za-z_$][A-Za-z0-9_$]*)*$"
     },
     "ruleSeverity": {
       "type": "string",

--- a/packages/resultar-check/src/rules-core.ts
+++ b/packages/resultar-check/src/rules-core.ts
@@ -158,7 +158,7 @@ export const normalizeNoUnsafeAwaitMode = (
 ): NoUnsafeAwaitMode => (value === "all" || value === "resultar-context" ? value : fallback);
 
 const isValidCallPath = (value: string): boolean =>
-  /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+$/u.test(value);
+  /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/u.test(value);
 
 export const normalizeNoUnsafeAwaitIgnoreCalls = (value: unknown): readonly string[] =>
   Array.isArray(value)

--- a/packages/resultar-check/tests/lint-cli.test.ts
+++ b/packages/resultar-check/tests/lint-cli.test.ts
@@ -133,15 +133,16 @@ describe("lint CLI and integration edges", () => {
     equal(normalizeNoUnsafeAwaitMode("all"), "all");
     equal(normalizeNoUnsafeAwaitMode("resultar-context"), "resultar-context");
     equal(normalizeNoUnsafeAwaitMode(false), defaultResultarRulesOptions.noUnsafeAwaitMode);
-    deepEqual(normalizeNoUnsafeAwaitIgnoreCalls(["fastify.after", "invalid path", 1]), [
-      "fastify.after",
-    ]);
+    deepEqual(
+      normalizeNoUnsafeAwaitIgnoreCalls(["startServer", "fastify.after", "invalid path", 1]),
+      ["startServer", "fastify.after"],
+    );
     deepEqual(normalizeNoUnsafeAwaitIgnoreCalls("fastify.after"), []);
 
     const parsed = parsePluginOptions({
       noDiscard: "off",
       noDiscardMode: "direct",
-      noUnsafeAwaitIgnoreCalls: ["fastify.after"],
+      noUnsafeAwaitIgnoreCalls: ["startServer", "fastify.after"],
       noUnsafeAwaitMode: "all",
       preferTaggedError: "suggestion",
       typedCatchMapper: "message",
@@ -149,7 +150,7 @@ describe("lint CLI and integration edges", () => {
 
     equal(parsed.noDiscard, "off");
     equal(parsed.noDiscardMode, "direct");
-    deepEqual(parsed.noUnsafeAwaitIgnoreCalls, ["fastify.after"]);
+    deepEqual(parsed.noUnsafeAwaitIgnoreCalls, ["startServer", "fastify.after"]);
     equal(parsed.noUnsafeAwaitMode, "all");
     equal(parsed.preferTaggedError, "suggestion");
     equal(parsed.typedCatchMapper, "message");
@@ -159,12 +160,12 @@ describe("lint CLI and integration edges", () => {
 
     const normalized = normalizeResultarRulesOptions({
       noDiscard: "off",
-      noUnsafeAwaitIgnoreCalls: ["fastify.after"],
+      noUnsafeAwaitIgnoreCalls: ["startServer", "fastify.after"],
       noUnsafeAwaitMode: "all",
       preferMapErr: "suggestion",
     });
     equal(normalized.noDiscard, "off");
-    deepEqual(normalized.noUnsafeAwaitIgnoreCalls, ["fastify.after"]);
+    deepEqual(normalized.noUnsafeAwaitIgnoreCalls, ["startServer", "fastify.after"]);
     equal(normalized.noUnsafeAwaitMode, "all");
     equal(normalized.preferMapErr, "suggestion");
 

--- a/packages/resultar-check/tests/resultar-rules.test.ts
+++ b/packages/resultar-check/tests/resultar-rules.test.ts
@@ -559,20 +559,24 @@ describe("Resultar lint rules", () => {
       "no-unsafe-await",
       `
         declare function fetch(input: string): Promise<string>
+        declare function startServer(): Promise<void>
+        declare function startApp(): Promise<void>
         declare const fastify: { after(): Promise<void>; ready(): Promise<void> }
         declare const app: { after(): Promise<void> }
 
         async function run() {
+          await startServer()
+          await startApp()
           await fastify.after()
           await app.after()
           await fastify.ready()
           await fetch("/still-unsafe")
         }
       `,
-      { noUnsafeAwaitIgnoreCalls: ["fastify.after"], noUnsafeAwaitMode: "all" },
+      { noUnsafeAwaitIgnoreCalls: ["startServer", "fastify.after"], noUnsafeAwaitMode: "all" },
     );
 
-    equal(findings.length, 3);
+    equal(findings.length, 4);
     equal(
       findings.every((finding) => finding.rule === "no-unsafe-await"),
       true,


### PR DESCRIPTION
## Summary

- Allow `noUnsafeAwaitIgnoreCalls` entries to be bare function identifiers such as `startServer`.
- Keep existing exact dotted call-path support such as `fastify.after`.
- Update schema, option normalization tests, rule tests, docs, lint examples, and bump `resultar-check` to `1.1.1`.

## Why

The URL shortener config needs to ignore a direct bootstrap call:

```json
"noUnsafeAwaitIgnoreCalls": ["startServer"]
```

`resultar-check@1.1.0` only accepted paths with at least one dot, so the schema/normalizer filtered out `startServer` even though the matcher can resolve identifier calls.

## Validation

- `pnpm --filter resultar-check check`
- `pnpm --filter resultar-check test`