### PR TITLE
[codex] Add stricter Resultar check rules

### DIFF
--- a/.changeset/bright-camels-check.md
+++ b/.changeset/bright-camels-check.md
@@ -1,0 +1,7 @@
+---
+"resultar-check": major
+---
+
+Add stricter Resultar diagnostics for `safeTry` and thrown errors.
+
+`resultar/no-await-in-safe-try` now defaults to an error so `safeTry` bodies compose Resultar values with `yield*` instead of raw `await`. The new opt-in `resultar/no-throw` rule lets projects enforce expected failures through `Err`/`errAsync` rather than thrown exceptions.

--- a/examples/lint/README.md
+++ b/examples/lint/README.md
@@ -27,7 +27,9 @@ The package `tsconfig.json` enables every Resultar rule as an error and opts int
 ```json
 {
   "name": "resultar-check",
+  "noAwaitInSafeTry": "error",
   "noDiscardMode": "must-use",
+  "noThrow": "error",
   "noUnsafeAwait": "error",
   "noUnsafeAwaitMode": "all",
   "noUnsafeAwaitIgnoreCalls": ["startServer", "fastify.after"]

--- a/examples/lint/scripts/smoke.ts
+++ b/examples/lint/scripts/smoke.ts
@@ -59,6 +59,8 @@ const expectedRules = [
   "resultar/prefer-map-err",
   "resultar/prefer-and-then",
   "resultar/typed-catch-mapper",
+  "resultar/no-throw",
+  "resultar/no-await-in-safe-try",
   "resultar/no-unsafe-await",
   "resultar/no-try-catch-in-safe-try",
   "resultar/yield-star-in-safe-try",

--- a/examples/lint/src/index.ts
+++ b/examples/lint/src/index.ts
@@ -134,6 +134,12 @@ export const noUnsafeAwaitRawPromiseBoundaryExample = async (): Promise<User> =>
 export const noUnsafeAwaitResultContextExample = async (): Promise<Result<User, FetchUserError>> =>
   ok(await fetchUser("unsafe-result-context"));
 
+// resultar/no-throw: expected failures should stay in Resultar channels instead
+// of escaping through throw control flow.
+export const noThrowExample = (): never => {
+  throw new SaveUserError({ id: "no-throw" });
+};
+
 const fastify = {
   after: async (): Promise<void> => undefined,
   ready: async (): Promise<void> => undefined,
@@ -180,6 +186,15 @@ export const noTryCatchInSafeTryExample = (): Result<User, SaveUserError> =>
     } catch {
       return SaveUserError.err({ id: "safe-try" });
     }
+  });
+
+// resultar/no-await-in-safe-try: inside safeTry, compose Resultar values with
+// yield*. Awaiting a ResultAsync unwraps the channel into ordinary control flow.
+export const noAwaitInSafeTryExample = (): ResultAsync<User, SaveUserError> =>
+  safeTry(async function* () {
+    const result = await saveUserAsync("await-in-safe-try");
+
+    return result;
   });
 
 // resultar/yield-star-in-safe-try: yield* is what unwraps Resultar values inside

--- a/examples/lint/src/resultar-clean.ts
+++ b/examples/lint/src/resultar-clean.ts
@@ -176,6 +176,15 @@ export const createUserWithGenerator = (
     return insertUser(availableEmail);
   });
 
+// no-await-in-safe-try: async safeTry generators use yield* for ResultAsync
+// values instead of await.
+export const loadUserWithSafeTry = (id: string): StrictResultAsync<User, FetchUserError> =>
+  safeTry(async function* () {
+    const user = yield* loadUser(id);
+
+    return ok(user);
+  });
+
 export const runStartupTask = (
   label: string,
   task: () => Promise<void>,

--- a/examples/lint/tsconfig.json
+++ b/examples/lint/tsconfig.json
@@ -12,8 +12,10 @@
     "plugins": [
       {
         "name": "resultar-check",
+        "noAwaitInSafeTry": "error",
         "noDiscard": "error",
         "noTaggedErrorConstructorOverride": "error",
+        "noThrow": "error",
         "noTryCatchInSafeTry": "error",
         "noUnsafeAwait": "error",
         "noUnsafeAwaitIgnoreCalls": ["startServer", "fastify.after"],

--- a/packages/resultar-check/README.md
+++ b/packages/resultar-check/README.md
@@ -170,6 +170,8 @@ still requires explicit plugin configuration with an absolute or package-root `l
 | `resultar/prefer-map-err`                       | `preferMapErr`                     | Prefer `mapErr` when `orElse` only returns another `Err`.                          |
 | `resultar/prefer-and-then`                      | `preferAndThen`                    | Prefer `andThen` / `asyncAndThen` when `map` returns a Resultar value.             |
 | `resultar/typed-catch-mapper`                   | `typedCatchMapper`                 | Require catch conversion helpers to map caught values to typed errors.             |
+| `resultar/no-throw`                             | `noThrow`                          | Disallow `throw` statements so expected failures stay in Resultar error channels.  |
+| `resultar/no-await-in-safe-try`                 | `noAwaitInSafeTry`                 | Disallow `await` inside `safeTry`; use `yield*` for Resultar values.               |
 | `resultar/no-unsafe-await`                      | `noUnsafeAwait`                    | Require raw Promise awaits in Resultar async contexts to use Resultar boundaries.  |
 | `resultar/no-try-catch-in-safe-try`             | `noTryCatchInSafeTry`              | Avoid raw `try/catch` inside `safeTry` generators.                                 |
 | `resultar/yield-star-in-safe-try`               | `yieldStarInSafeTry`               | Require `yield*` for Resultar values inside `safeTry`.                             |
@@ -180,6 +182,16 @@ still requires explicit plugin configuration with an absolute or package-root `l
 | `resultar/no-useless-recovery`                  | `noUselessRecovery`                | Flag recovery calls on `Result<T, never>` / `ResultAsync<T, never>`.               |
 
 Each option accepts `"error"`, `"warning"`, `"suggestion"`, `"message"`, or `"off"`.
+`noThrow` defaults to `"off"` because it is a strict migration rule. Enable it when expected
+domain/application failures should always return `Err`/`errAsync` instead of throwing. It reports all
+`throw` statements in inspected source files, including throws inside `tryResultAsync` boundaries;
+use `ignoreFilePatterns` for test, script, or process-boundary files that intentionally throw.
+
+`noAwaitInSafeTry` defaults to `"warning"` and reports every `await` expression inside an inspectable
+`safeTry` body. Use `yield*` for both `Result` and `ResultAsync` values; wrap raw Promises with a
+Resultar helper before yielding them. Nested functions inside `safeTry` are not inspected by this
+rule.
+
 `noUnsafeAwait` defaults to `"off"` because it is an architectural rule and may require migration in
 existing async code. Enable it explicitly when a project is ready to enforce Resultar async
 boundaries. By default, `noUnsafeAwait` uses `noUnsafeAwaitMode: "resultar-context"` and checks

--- a/packages/resultar-check/README.md
+++ b/packages/resultar-check/README.md
@@ -187,7 +187,7 @@ domain/application failures should always return `Err`/`errAsync` instead of thr
 `throw` statements in inspected source files, including throws inside `tryResultAsync` boundaries;
 use `ignoreFilePatterns` for test, script, or process-boundary files that intentionally throw.
 
-`noAwaitInSafeTry` defaults to `"warning"` and reports every `await` expression inside an inspectable
+`noAwaitInSafeTry` defaults to `"error"` and reports every `await` expression inside an inspectable
 `safeTry` body. Use `yield*` for both `Result` and `ResultAsync` values; wrap raw Promises with a
 Resultar helper before yielding them. Nested functions inside `safeTry` are not inspected by this
 rule.

--- a/packages/resultar-check/schema.json
+++ b/packages/resultar-check/schema.json
@@ -50,6 +50,11 @@
           "default": [],
           "description": "Glob-style file patterns that Resultar diagnostics should ignore. Bare patterns such as *.test.ts match file basenames; slash patterns such as tests/** match normalized path suffixes."
         },
+        "noAwaitInSafeTry": {
+          "$ref": "#/definitions/ruleSeverity",
+          "default": "warning",
+          "description": "Disallow await expressions inside safeTry bodies; use yield* for Resultar values."
+        },
         "noDiscard": {
           "$ref": "#/definitions/ruleSeverity",
           "default": "error",
@@ -65,6 +70,11 @@
           "$ref": "#/definitions/ruleSeverity",
           "default": "warning",
           "description": "Keep the generated tagged-error constructor intact."
+        },
+        "noThrow": {
+          "$ref": "#/definitions/ruleSeverity",
+          "default": "off",
+          "description": "Disallow throw statements so expected failures stay in Resultar error channels."
         },
         "noTryCatchInSafeTry": {
           "$ref": "#/definitions/ruleSeverity",

--- a/packages/resultar-check/schema.json
+++ b/packages/resultar-check/schema.json
@@ -52,7 +52,7 @@
         },
         "noAwaitInSafeTry": {
           "$ref": "#/definitions/ruleSeverity",
-          "default": "warning",
+          "default": "error",
           "description": "Disallow await expressions inside safeTry bodies; use yield* for Resultar values."
         },
         "noDiscard": {

--- a/packages/resultar-check/src/diagnostics.ts
+++ b/packages/resultar-check/src/diagnostics.ts
@@ -12,8 +12,10 @@ import { shouldInspectSourceFile } from "./source-files.js";
 export const RESULTAR_DIAGNOSTIC_SOURCE = "resultar";
 export const RESULTAR_NO_DISCARD_DIAGNOSTIC_CODE = 91_001;
 export const RESULTAR_RULE_DIAGNOSTIC_CODES: Record<ResultarRuleName, number> = {
+  "no-await-in-safe-try": 91_014,
   "no-discard": RESULTAR_NO_DISCARD_DIAGNOSTIC_CODE,
   "no-tagged-error-constructor-override": 91_010,
+  "no-throw": 91_013,
   "no-try-catch-in-safe-try": 91_006,
   "no-unsafe-await": 91_012,
   "no-useless-recovery": 91_011,

--- a/packages/resultar-check/src/finding.ts
+++ b/packages/resultar-check/src/finding.ts
@@ -1,6 +1,8 @@
 export type ResultarRuleName =
   | "no-discard"
+  | "no-await-in-safe-try"
   | "no-tagged-error-constructor-override"
+  | "no-throw"
   | "no-try-catch-in-safe-try"
   | "no-unsafe-await"
   | "no-useless-recovery"

--- a/packages/resultar-check/src/plugin-options.ts
+++ b/packages/resultar-check/src/plugin-options.ts
@@ -23,12 +23,17 @@ export const parsePluginOptions = (config: unknown): ResultarLanguageServiceOpti
 
   return {
     ignoreFilePatterns: normalizeIgnoreFilePatterns(config.ignoreFilePatterns),
+    noAwaitInSafeTry: normalizeRuleSeverity(
+      config.noAwaitInSafeTry,
+      defaultResultarRulesOptions.noAwaitInSafeTry,
+    ),
     noDiscard: normalizeRuleSeverity(config.noDiscard, defaultResultarRulesOptions.noDiscard),
     noDiscardMode: normalizeNoDiscardMode(config.noDiscardMode),
     noTaggedErrorConstructorOverride: normalizeRuleSeverity(
       config.noTaggedErrorConstructorOverride,
       defaultResultarRulesOptions.noTaggedErrorConstructorOverride,
     ),
+    noThrow: normalizeRuleSeverity(config.noThrow, defaultResultarRulesOptions.noThrow),
     noTryCatchInSafeTry: normalizeRuleSeverity(
       config.noTryCatchInSafeTry,
       defaultResultarRulesOptions.noTryCatchInSafeTry,

--- a/packages/resultar-check/src/rules-core.ts
+++ b/packages/resultar-check/src/rules-core.ts
@@ -46,9 +46,11 @@ type SafeTryBody =
 
 export interface ResultarRulesOptions {
   readonly ignoreFilePatterns: readonly string[];
+  readonly noAwaitInSafeTry: ResultarRuleSeverity;
   readonly noDiscard: ResultarRuleSeverity;
   readonly noDiscardMode: NoDiscardMode;
   readonly noTaggedErrorConstructorOverride: ResultarRuleSeverity;
+  readonly noThrow: ResultarRuleSeverity;
   readonly noTryCatchInSafeTry: ResultarRuleSeverity;
   readonly noUnsafeAwait: ResultarRuleSeverity;
   readonly noUnsafeAwaitIgnoreCalls: readonly string[];
@@ -68,6 +70,8 @@ export const resultarRuleNames: readonly ResultarRuleName[] = [
   "prefer-map-err",
   "prefer-and-then",
   "typed-catch-mapper",
+  "no-throw",
+  "no-await-in-safe-try",
   "no-unsafe-await",
   "no-try-catch-in-safe-try",
   "yield-star-in-safe-try",
@@ -79,8 +83,10 @@ export const resultarRuleNames: readonly ResultarRuleName[] = [
 ];
 
 export const ruleOptionNameByRule: Record<ResultarRuleName, ResultarRuleOptionName> = {
+  "no-await-in-safe-try": "noAwaitInSafeTry",
   "no-discard": "noDiscard",
   "no-tagged-error-constructor-override": "noTaggedErrorConstructorOverride",
+  "no-throw": "noThrow",
   "no-try-catch-in-safe-try": "noTryCatchInSafeTry",
   "no-unsafe-await": "noUnsafeAwait",
   "no-useless-recovery": "noUselessRecovery",
@@ -95,9 +101,11 @@ export const ruleOptionNameByRule: Record<ResultarRuleName, ResultarRuleOptionNa
 
 export const defaultResultarRulesOptions: ResultarRulesOptions = {
   ignoreFilePatterns: [],
+  noAwaitInSafeTry: "warning",
   noDiscard: "error",
   noDiscardMode: "must-use",
   noTaggedErrorConstructorOverride: "warning",
+  noThrow: "off",
   noTryCatchInSafeTry: "warning",
   noUnsafeAwait: "off",
   noUnsafeAwaitIgnoreCalls: [],
@@ -174,12 +182,17 @@ export const normalizeResultarRulesOptions = (
   options: Partial<ResultarRulesOptions> = {},
 ): ResultarRulesOptions => ({
   ignoreFilePatterns: normalizeIgnoreFilePatterns(options.ignoreFilePatterns),
+  noAwaitInSafeTry: normalizeRuleSeverity(
+    options.noAwaitInSafeTry,
+    defaultResultarRulesOptions.noAwaitInSafeTry,
+  ),
   noDiscard: normalizeRuleSeverity(options.noDiscard, defaultResultarRulesOptions.noDiscard),
   noDiscardMode: normalizeNoDiscardMode(options.noDiscardMode),
   noTaggedErrorConstructorOverride: normalizeRuleSeverity(
     options.noTaggedErrorConstructorOverride,
     defaultResultarRulesOptions.noTaggedErrorConstructorOverride,
   ),
+  noThrow: normalizeRuleSeverity(options.noThrow, defaultResultarRulesOptions.noThrow),
   noTryCatchInSafeTry: normalizeRuleSeverity(
     options.noTryCatchInSafeTry,
     defaultResultarRulesOptions.noTryCatchInSafeTry,
@@ -1058,6 +1071,31 @@ const getTypedCatchMapperFindings = (
   return findings;
 };
 
+const getNoThrowFindings = (
+  context: RuleContext,
+  severity: EnabledRuleSeverity,
+): readonly ResultarLintFinding[] => {
+  const findings: ResultarLintFinding[] = [];
+
+  visitSourceFile(context, (node) => {
+    if (!context.tsApi.isThrowStatement(node)) {
+      return;
+    }
+
+    findings.push(
+      createFinding(
+        context,
+        node,
+        "no-throw",
+        severity,
+        "Do not throw for expected Resultar failures. Return `Err`/`errAsync` or wrap uncontrolled external code with a Resultar catch boundary.",
+      ),
+    );
+  });
+
+  return findings;
+};
+
 const collectResultarAwaitBoundaryBodies = (context: RuleContext): ReadonlySet<ts.Node> => {
   const bodies = new Set<ts.Node>();
 
@@ -1184,6 +1222,41 @@ const getNoTryCatchInSafeTryFindings = (
             "no-try-catch-in-safe-try",
             severity,
             "Avoid raw try/catch inside `safeTry`. Use `safeTry({ try, catch })`, `tryResult`, or `tryResultAsync` to keep failures typed.",
+          ),
+        );
+      }
+    });
+  });
+
+  return findings;
+};
+
+const getNoAwaitInSafeTryFindings = (
+  context: RuleContext,
+  severity: EnabledRuleSeverity,
+): readonly ResultarLintFinding[] => {
+  const findings: ResultarLintFinding[] = [];
+
+  visitSourceFile(context, (node) => {
+    if (!context.tsApi.isCallExpression(node)) {
+      return;
+    }
+
+    const safeTryBody = getSafeTryBody(context.tsApi, node);
+
+    if (safeTryBody === undefined) {
+      return;
+    }
+
+    visitSafeTryBody(context.tsApi, safeTryBody, (bodyNode) => {
+      if (context.tsApi.isAwaitExpression(bodyNode)) {
+        findings.push(
+          createFinding(
+            context,
+            bodyNode,
+            "no-await-in-safe-try",
+            severity,
+            "Do not use `await` inside `safeTry`. Use `yield*` for Resultar values and wrap raw Promises before yielding them.",
           ),
         );
       }
@@ -1503,6 +1576,8 @@ export const getSourceFileResultarFindings = (
     ["prefer-map-err", getPreferMapErrFindings],
     ["prefer-and-then", getPreferAndThenFindings],
     ["typed-catch-mapper", getTypedCatchMapperFindings],
+    ["no-throw", getNoThrowFindings],
+    ["no-await-in-safe-try", getNoAwaitInSafeTryFindings],
     ["no-try-catch-in-safe-try", getNoTryCatchInSafeTryFindings],
     ["yield-star-in-safe-try", getYieldStarInSafeTryFindings],
     ["unsafe-result-type-assertion", getUnsafeResultTypeAssertionFindings],

--- a/packages/resultar-check/src/rules-core.ts
+++ b/packages/resultar-check/src/rules-core.ts
@@ -101,7 +101,7 @@ export const ruleOptionNameByRule: Record<ResultarRuleName, ResultarRuleOptionNa
 
 export const defaultResultarRulesOptions: ResultarRulesOptions = {
   ignoreFilePatterns: [],
-  noAwaitInSafeTry: "warning",
+  noAwaitInSafeTry: "error",
   noDiscard: "error",
   noDiscardMode: "must-use",
   noTaggedErrorConstructorOverride: "warning",

--- a/packages/resultar-check/tests/lint-cli.test.ts
+++ b/packages/resultar-check/tests/lint-cli.test.ts
@@ -150,8 +150,10 @@ describe("lint CLI and integration edges", () => {
 
     const parsed = parsePluginOptions({
       ignoreFilePatterns: ["*.test.ts"],
+      noAwaitInSafeTry: "error",
       noDiscard: "off",
       noDiscardMode: "direct",
+      noThrow: "error",
       noUnsafeAwaitIgnoreCalls: ["startServer", "fastify.after"],
       noUnsafeAwaitMode: "all",
       preferTaggedError: "suggestion",
@@ -159,25 +161,33 @@ describe("lint CLI and integration edges", () => {
     });
 
     deepEqual(parsed.ignoreFilePatterns, ["*.test.ts"]);
+    equal(parsed.noAwaitInSafeTry, "error");
     equal(parsed.noDiscard, "off");
     equal(parsed.noDiscardMode, "direct");
+    equal(parsed.noThrow, "error");
     deepEqual(parsed.noUnsafeAwaitIgnoreCalls, ["startServer", "fastify.after"]);
     equal(parsed.noUnsafeAwaitMode, "all");
     equal(parsed.preferTaggedError, "suggestion");
     equal(parsed.typedCatchMapper, "message");
 
     const fallback = parsePluginOptions("not an object");
+    equal(fallback.noAwaitInSafeTry, defaultResultarRulesOptions.noAwaitInSafeTry);
     equal(fallback.noDiscard, defaultResultarRulesOptions.noDiscard);
+    equal(fallback.noThrow, defaultResultarRulesOptions.noThrow);
 
     const normalized = normalizeResultarRulesOptions({
       ignoreFilePatterns: ["*.test.ts"],
+      noAwaitInSafeTry: "message",
       noDiscard: "off",
+      noThrow: "warning",
       noUnsafeAwaitIgnoreCalls: ["startServer", "fastify.after"],
       noUnsafeAwaitMode: "all",
       preferMapErr: "suggestion",
     });
     deepEqual(normalized.ignoreFilePatterns, ["*.test.ts"]);
+    equal(normalized.noAwaitInSafeTry, "message");
     equal(normalized.noDiscard, "off");
+    equal(normalized.noThrow, "warning");
     deepEqual(normalized.noUnsafeAwaitIgnoreCalls, ["startServer", "fastify.after"]);
     equal(normalized.noUnsafeAwaitMode, "all");
     equal(normalized.preferMapErr, "suggestion");

--- a/packages/resultar-check/tests/resultar-rules.test.ts
+++ b/packages/resultar-check/tests/resultar-rules.test.ts
@@ -224,7 +224,7 @@ describe("Resultar lint rules", () => {
         `Expected ${ruleName} fixture to produce a ${ruleName} finding`,
       );
     }
-  }, 30_000);
+  }, 90_000);
 
   it("flags orElse callbacks that only return Err", async () => {
     const findings = await runRule(

--- a/packages/resultar-check/tests/resultar-rules.test.ts
+++ b/packages/resultar-check/tests/resultar-rules.test.ts
@@ -167,6 +167,24 @@ describe("Resultar lint rules", () => {
           tryResult(() => JSON.parse("{}"))
         `,
       },
+      "no-throw": {
+        source: `
+          declare const error: Error
+
+          throw error
+        `,
+      },
+      "no-await-in-safe-try": {
+        source: `
+          declare function loadUser(): Promise<string>
+          declare function safeTry(value: unknown): unknown
+
+          safeTry(async function* () {
+            const user = await loadUser()
+            return user
+          })
+        `,
+      },
       "unsafe-result-type-assertion": {
         source: `
           type Result<T, E> = { readonly value?: T; readonly error?: E }
@@ -384,6 +402,43 @@ describe("Resultar lint rules", () => {
     deepEqual(typedReturnFindings, []);
     deepEqual(objectMapperFindings, []);
     equal(spreadPropertyFindings.length, 1);
+  });
+
+  it("flags throw statements including tagged errors inside Resultar boundaries", async () => {
+    const findings = await runRule(
+      "no-throw",
+      `
+        declare function tryResultAsync(value: unknown): unknown
+
+        class ValidationError extends Error {
+          static of(message: string): ValidationError {
+            return new ValidationError(message)
+          }
+        }
+
+        const parseBase64Image = (base64Image: string): string => {
+          if (!base64Image.startsWith("data:")) {
+            throw ValidationError.of("Imagem base64 inválida.")
+          }
+
+          return base64Image
+        }
+
+        tryResultAsync({
+          try: async () => {
+            throw ValidationError.of("S3 storage is not configured.")
+          },
+          catch: (error: unknown) => error
+        })
+      `,
+    );
+
+    equal(findings.length, 2);
+    deepEqual(
+      findings.map((finding) => finding.rule),
+      ["no-throw", "no-throw"],
+    );
+    isTrue(findings[0]?.message.includes("Return `Err`/`errAsync`"));
   });
 
   it("flags unsafe awaits outside Resultar async boundaries in all mode", async () => {
@@ -719,6 +774,60 @@ describe("Resultar lint rules", () => {
           }
 
           return nested()
+        })
+      `,
+    );
+
+    deepEqual(findings, []);
+  });
+
+  it("flags await expressions inside safeTry bodies", async () => {
+    const findings = await runRule(
+      "no-await-in-safe-try",
+      `
+        declare function loadUser(): Promise<string>
+        declare function loadProfile(): Promise<string>
+        declare function safeTry(value: unknown): unknown
+
+        safeTry(async function* () {
+          const user = await loadUser()
+          return user
+        })
+
+        safeTry({
+          try: async function* () {
+            const profile = await loadProfile()
+            return profile
+          },
+          catch: (error: unknown) => error
+        })
+      `,
+    );
+
+    equal(findings.length, 2);
+    deepEqual(
+      findings.map((finding) => finding.rule),
+      ["no-await-in-safe-try", "no-await-in-safe-try"],
+    );
+    isTrue(findings[0]?.message.includes("Use `yield*`"));
+  });
+
+  it("allows yield star and does not inspect nested functions inside safeTry", async () => {
+    const findings = await runRule(
+      "no-await-in-safe-try",
+      `
+        type Result<T, E> = { readonly value?: T; readonly error?: E }
+        declare function safeTry<T, E>(fn: () => AsyncGenerator<Result<never, E>, T>): Result<T, E>
+        declare function loadUser(): Result<string, Error>
+        declare function loadNested(): Promise<string>
+
+        safeTry(async function* () {
+          async function nested() {
+            return await loadNested()
+          }
+
+          const user = yield* loadUser()
+          return user
         })
       `,
     );


### PR DESCRIPTION
## Summary
- Add stricter `resultar-check` diagnostics for thrown errors and unsafe awaits inside `safeTry`.
- Wire the new rule options through diagnostics, schema, plugin options, and tests.
- Update the lint example and README coverage for the new rules.

## Validation
- `pnpm --filter resultar-check check:full`

## Notes
- This branch does not include a changeset yet; add one before release if this should publish a new `resultar-check` version.