### PR TITLE
Enhance Resultar guidance and diagnostics

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -20,7 +20,7 @@
     "cronometro": "^6.0.3",
     "eslint": "10.6.0",
     "neverthrow": "^8.2.0",
-    "oxlint": "1.72.0",
+    "oxlint": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:"
   }

--- a/examples/lint/README.md
+++ b/examples/lint/README.md
@@ -31,11 +31,11 @@ pnpm run check:oxlint
 
 The three explicit check scripts are:
 
-| Script                  | Host                  | Config file                       |
-| ----------------------- | --------------------- | --------------------------------- |
-| `check:oxlint`          | Oxlint JS plugin      | `oxlint.config.json`              |
-| `check:eslint`          | ESLint flat config    | `eslint.config.mjs`               |
-| `check:resultar-check`  | `resultar-check` CLI  | `tsconfig.resultar-check.json`    |
+| Script                 | Host                 | Config file                    |
+| ---------------------- | -------------------- | ------------------------------ |
+| `check:oxlint`         | Oxlint JS plugin     | `oxlint.config.json`           |
+| `check:eslint`         | ESLint flat config   | `eslint.config.mjs`            |
+| `check:resultar-check` | `resultar-check` CLI | `tsconfig.resultar-check.json` |
 
 All three are expected to return the same Resultar diagnostic count for this fixture because they
 enable the same AST-only rule subset. The smoke test normalizes the different reporter formats:
@@ -44,13 +44,14 @@ enable the same AST-only rule subset. The smoke test normalizes the different re
 - ESLint: `resultar/rule-name`
 - `resultar-check` CLI: `resultar/rule-name`
 
-The expected count is 12 diagnostics:
+The expected count is 14 diagnostics:
 
 | Rule                                            | Count |
 | ----------------------------------------------- | ----: |
 | `resultar/no-await-in-safe-try`                 |     1 |
 | `resultar/no-tagged-error-constructor-override` |     1 |
 | `resultar/no-throw`                             |     3 |
+| `resultar/no-try-catch`                         |     2 |
 | `resultar/no-try-catch-in-safe-try`             |     1 |
 | `resultar/prefer-tagged-error`                  |     3 |
 | `resultar/tagged-error-name-match`              |     1 |
@@ -76,6 +77,7 @@ Oxlint is the fastest adapter path and is the default `check` script for this ex
     "resultar/no-await-in-safe-try": "error",
     "resultar/no-tagged-error-constructor-override": "error",
     "resultar/no-throw": "error",
+    "resultar/no-try-catch": "error",
     "resultar/no-try-catch-in-safe-try": "error",
     "resultar/prefer-tagged-error": "error",
     "resultar/tagged-error-name-match": "error",
@@ -101,13 +103,14 @@ export default [
       "resultar/no-await-in-safe-try": "error",
       "resultar/no-tagged-error-constructor-override": "error",
       "resultar/no-throw": "error",
+      "resultar/no-try-catch": "error",
       "resultar/no-try-catch-in-safe-try": "error",
       "resultar/prefer-tagged-error": "error",
       "resultar/tagged-error-name-match": "error",
       "resultar/typed-catch-mapper": "error",
-      "resultar/yield-star-in-safe-try": "error"
-    }
-  }
+      "resultar/yield-star-in-safe-try": "error",
+    },
+  },
 ];
 ```
 
@@ -129,6 +132,7 @@ CLI comparable with Oxlint and ESLint instead of reporting extra type-aware diag
         "noDiscard": "off",
         "noTaggedErrorConstructorOverride": "error",
         "noThrow": "error",
+        "noTryCatch": "error",
         "noTryCatchInSafeTry": "error",
         "noUnsafeAwait": "off",
         "noUselessRecovery": "off",

--- a/examples/lint/eslint.config.mjs
+++ b/examples/lint/eslint.config.mjs
@@ -5,6 +5,7 @@ const resultarRules = {
   "resultar/no-await-in-safe-try": "error",
   "resultar/no-tagged-error-constructor-override": "error",
   "resultar/no-throw": "error",
+  "resultar/no-try-catch": "error",
   "resultar/no-try-catch-in-safe-try": "error",
   "resultar/prefer-tagged-error": "error",
   "resultar/tagged-error-name-match": "error",

--- a/examples/lint/oxlint.config.json
+++ b/examples/lint/oxlint.config.json
@@ -11,6 +11,7 @@
     "resultar/no-await-in-safe-try": "error",
     "resultar/no-tagged-error-constructor-override": "error",
     "resultar/no-throw": "error",
+    "resultar/no-try-catch": "error",
     "resultar/no-try-catch-in-safe-try": "error",
     "resultar/prefer-tagged-error": "error",
     "resultar/tagged-error-name-match": "error",

--- a/examples/lint/package.json
+++ b/examples/lint/package.json
@@ -19,7 +19,7 @@
     "@babel/plugin-syntax-typescript": "8.0.3",
     "@types/node": "catalog:",
     "eslint": "10.6.0",
-    "oxlint": "1.72.0",
+    "oxlint": "catalog:",
     "resultar-check": "workspace:*",
     "tsx": "catalog:",
     "typescript": "7.0.2"

--- a/examples/lint/scripts/smoke.ts
+++ b/examples/lint/scripts/smoke.ts
@@ -58,6 +58,7 @@ const expectedRules = [
   "no-await-in-safe-try",
   "no-tagged-error-constructor-override",
   "no-throw",
+  "no-try-catch",
   "no-try-catch-in-safe-try",
   "prefer-tagged-error",
   "tagged-error-name-match",
@@ -81,8 +82,6 @@ const checkScripts = [
   { label: "resultar-check CLI", script: "check:resultar-check" },
 ] as const;
 
-const countText = (value: string, expected: string): number => value.split(expected).length - 1;
-
 const normalizeResultarRuleIds = (output: string): string =>
   expectedRules.reduce(
     (current, rule) => current.replaceAll(`resultar(${rule})`, `resultar/${rule}`),
@@ -91,10 +90,13 @@ const normalizeResultarRuleIds = (output: string): string =>
 
 const countRuleDiagnostics = (output: string): RuleCounts => {
   const normalized = normalizeResultarRuleIds(output);
-  const entries = expectedRules.map((rule) => [
-    rule,
-    countText(normalized, `resultar/${rule}`),
-  ] as const);
+  const entries = expectedRules.map(
+    (rule) =>
+      [
+        rule,
+        [...normalized.matchAll(new RegExp(`resultar/${rule}(?![a-z-])`, "gu"))].length,
+      ] as const,
+  );
 
   return Object.fromEntries(entries) as RuleCounts;
 };

--- a/examples/lint/src/index.ts
+++ b/examples/lint/src/index.ts
@@ -108,8 +108,7 @@ export const preferAndThenExample = () =>
 
 // resultar/typed-catch-mapper: tryResult without a catch mapper leaves the error
 // channel as unknown instead of converting the thrown value to a domain error.
-export const typedCatchMapperExample = () =>
-  tryResult(() => JSON.parse("{\"id\":\"parsed\"}") as User);
+export const typedCatchMapperExample = () => tryResult(() => JSON.parse('{"id":"parsed"}') as User);
 
 // resultar/no-unsafe-await: raw Promise awaits can reject outside Resultar. In
 // all mode, this is reported even outside functions returning Result/ResultAsync.
@@ -138,6 +137,16 @@ export const noUnsafeAwaitResultContextExample = async (): Promise<Result<User, 
 // of escaping through throw control flow.
 export const noThrowExample = (): never => {
   throw new SaveUserError({ id: "no-throw" });
+};
+
+// resultar/no-try-catch: expected failures should be converted at the throwing
+// boundary with tryResult or tryResultAsync instead of broad exception control flow.
+export const noTryCatchExample = (input: string): User | undefined => {
+  try {
+    return JSON.parse(input) as User;
+  } catch {
+    return undefined;
+  }
 };
 
 const fastify = {
@@ -225,10 +234,7 @@ type RecordIdParts = {
 // resultar/prefer-tagged-error: throwing new Error(...) also loses stable tags
 // and typed metadata. Convert throwing helpers to Resultar boundaries or throw a
 // createTaggedError instance when a throw boundary is intentional.
-export const preferTaggedErrorThrowExample = (
-  value: unknown,
-  table: string,
-): RecordIdParts => {
+export const preferTaggedErrorThrowExample = (value: unknown, table: string): RecordIdParts => {
   if (typeof value === "string") {
     return { id: value, table };
   }
@@ -242,6 +248,4 @@ export const legacyErrorInstance = new LegacyDomainError("legacy");
 // resultar/no-useless-recovery: mapErr/orElse/catchTag cannot run when the error
 // channel is never. Remove the recovery or make the operation actually fallible.
 export const noUselessRecoveryExample = (): Result<User, never> =>
-  ok<User, never>({ email: "infallible@example.com", id: "infallible" }).mapErr(
-    (error) => error,
-  );
+  ok<User, never>({ email: "infallible@example.com", id: "infallible" }).mapErr((error) => error);

--- a/examples/lint/tsconfig.resultar-check.json
+++ b/examples/lint/tsconfig.resultar-check.json
@@ -9,6 +9,7 @@
         "noDiscard": "off",
         "noTaggedErrorConstructorOverride": "error",
         "noThrow": "error",
+        "noTryCatch": "error",
         "noTryCatchInSafeTry": "error",
         "noUnsafeAwait": "off",
         "noUselessRecovery": "off",

--- a/examples/request/tsconfig.json
+++ b/examples/request/tsconfig.json
@@ -14,6 +14,7 @@
         "name": "resultar-check",
         "noDiscard": "error",
         "noTaggedErrorConstructorOverride": "error",
+        "noTryCatch": "error",
         "noTryCatchInSafeTry": "error",
         "noUselessRecovery": "error",
         "preferAndThen": "error",

--- a/examples/resultar/tsconfig.json
+++ b/examples/resultar/tsconfig.json
@@ -13,6 +13,7 @@
         "name": "resultar-check",
         "noDiscard": "error",
         "noTaggedErrorConstructorOverride": "error",
+        "noTryCatch": "error",
         "noTryCatchInSafeTry": "error",
         "noUselessRecovery": "error",
         "preferAndThen": "error",

--- a/packages/check/CHANGELOG.md
+++ b/packages/check/CHANGELOG.md
@@ -1,5 +1,13 @@
 # resultar-check
 
+## 2.2.0
+
+### Minor Changes
+
+- Add the opt-in `resultar/no-try-catch` rule for the CLI, TypeScript language-service plugin,
+  Oxlint, ESLint, and Deno Lint. The rule directs expected failures to `tryResult` or
+  `tryResultAsync` while continuing to allow `try/finally` cleanup.
+
 ## 2.1.1
 
 ### Patch Changes

--- a/packages/check/README.md
+++ b/packages/check/README.md
@@ -1,7 +1,7 @@
 # Resultar Check
 
-**Resultar-aware linting for TypeScript >=7. Fast feedback with Oxlint, full semantic enforcement
-with the TypeScript checker.**
+**Resultar-aware diagnostics for TypeScript >=7. Start with the CLI and TypeScript language server;
+use lint adapters for additional AST-only feedback.**
 
 TypeScript can prove that a value has type `Result<T, E>`. It cannot prove that the value was handled,
 that a `safeTry` flow preserved its error channel, or that application code avoided falling back to
@@ -10,13 +10,14 @@ contracts without Resultar-specific rules.
 
 `resultar-check` turns those contracts into executable project policy. One package provides:
 
-- an **Oxlint JavaScript plugin** for fast, syntax-only feedback;
-- a **TypeScript language-service plugin** for diagnostics in the editor;
 - a **CLI** that runs TypeScript first and then applies every Resultar rule over the same project;
+- a **TypeScript language-service plugin** for the same diagnostics in the editor;
+- an **Oxlint JavaScript plugin** for optional fast, syntax-only feedback;
 - equivalent AST-only adapters for **ESLint** and **Deno Lint**.
 
-Use Oxlint continuously while writing code, then keep the full checker as the type-aware quality gate.
-Both surfaces use stable `resultar/*` rule IDs, so local feedback and CI speak the same language.
+Use the CLI as the project and CI quality gate, and use the TypeScript language server for feedback
+while editing. Oxlint, ESLint, and Deno Lint are optional AST-only integrations for existing lint
+stacks. All surfaces use stable `resultar/*` rule IDs.
 
 ## Why Resultar Check
 
@@ -35,8 +36,8 @@ Resultar Check protects that design at review time:
   they bypass typed error channels.
 - **Keep domain errors predictable.** Enforce tagged-error construction, names, metadata, and typed
   catch mappers.
-- **Adopt incrementally.** Run eight syntax-only rules through Oxlint, or enable the full set of
-  fourteen rules when type information is available.
+- **Adopt incrementally.** Start with the CLI and TypeScript language server, then add the nine
+  syntax-only rules through Oxlint, ESLint, or Deno Lint when those hosts are useful.
 
 ### Deterministic Guardrails For AI-Assisted Code
 
@@ -47,9 +48,10 @@ patterns may be reasonable in another codebase but violate a Resultar architectu
 Resultar Check gives that probabilistic workflow a deterministic correction loop:
 
 1. The agent writes or refactors code.
-2. Oxlint reports structural Resultar mistakes immediately.
-3. `resultar-check` verifies type-aware contracts across the project.
-4. The agent receives a stable rule ID and an actionable diagnostic instead of relying on reviewer
+2. `resultar-check` verifies type-aware contracts across the project.
+3. The TypeScript language server reports the same rules beside editor type errors.
+4. Optional lint adapters report syntax-only issues in the project's existing lint stack.
+5. The agent receives a stable rule ID and an actionable diagnostic instead of relying on reviewer
    memory.
 
 This works with any coding agent that can run project commands; no model-specific integration is
@@ -60,74 +62,48 @@ and agents to validate the same rules repeatedly.
 
 | Stage | Tool | What it catches | Why use it |
 | --- | --- | --- | --- |
-| Write, save, staged files | Oxlint + Resultar plugin | Eight syntax-only Resultar rules | Fast feedback without creating a TypeScript Program |
-| Editor | TypeScript plugin | Full Resultar diagnostics beside TypeScript errors | Problems appear where code is written |
-| CI and release | `resultar-check` CLI | TypeScript diagnostics plus all fourteen Resultar rules | Authoritative project-wide gate |
-| Existing lint stack | ESLint or Deno Lint adapter | Same eight AST-only rules | Adopt Resultar policy without replacing the host |
+| CI, release, and explicit project checks | `resultar-check` CLI | TypeScript diagnostics plus all fifteen Resultar rules | Authoritative project-wide gate |
+| Editor | TypeScript language-service plugin | Full Resultar diagnostics beside TypeScript errors | Problems appear where code is written |
+| Write, save, staged files | Oxlint + Resultar plugin | Nine syntax-only Resultar rules | Optional low-latency structural feedback |
+| Existing lint stack | ESLint or Deno Lint adapter | Same nine AST-only rules | Adopt Resultar policy without replacing the host |
 
-The recommended default is **Oxlint for the inner loop plus `resultar-check` for CI**. Oxlint is not a
-reduced replacement for the full checker; it is the low-latency first layer.
+The recommended default is **`resultar-check` for project and CI checks plus the TypeScript
+language-service plugin for editor diagnostics**. Add Oxlint, ESLint, or Deno Lint only when their
+AST-only feedback fits the surrounding toolchain; none replaces the full checker.
 
-## Quick Start With Oxlint
+## Quick Start With the CLI
 
-Install Resultar Check and Oxlint:
-
-```sh
-pnpm add -D resultar-check oxlint
-```
-
-Create `oxlint.config.json`:
-
-```json
-{
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "jsPlugins": [
-    {
-      "name": "resultar",
-      "specifier": "./node_modules/resultar-check/dist/eslint/plugin.js"
-    }
-  ],
-  "rules": {
-    "resultar/no-await-in-safe-try": "error",
-    "resultar/no-tagged-error-constructor-override": "error",
-    "resultar/no-throw": "error",
-    "resultar/no-try-catch-in-safe-try": "error",
-    "resultar/prefer-tagged-error": "error",
-    "resultar/tagged-error-name-match": "error",
-    "resultar/typed-catch-mapper": "error",
-    "resultar/yield-star-in-safe-try": "error"
-  }
-}
-```
-
-Add scripts for both feedback layers:
-
-```json
-{
-  "scripts": {
-    "lint:resultar": "oxlint --config oxlint.config.json",
-    "check:resultar": "resultar-check"
-  }
-}
-```
-
-Run Oxlint on every local lint pass and `resultar-check` in CI. The AST-only rules need no type
-information; the CLI requires a project-local TypeScript >=7 for the complete rule set.
-
-See the runnable
-[lint adapter example](https://github.com/inaiat/resultar/tree/main/examples/lint) for a parity test
-that verifies Oxlint, ESLint, and the CLI against the same Resultar violations.
-
-## Add The Full Type-Aware Gate
-
-Install project-local TypeScript >=7 for editor diagnostics and CLI checks:
+Install Resultar Check and a project-local TypeScript >=7:
 
 ```sh
 pnpm add -D resultar-check "typescript@>=7"
 ```
 
-`resultar-check` defaults to `tsconfig.json` and passes `--noEmit` to TypeScript unless a
-`--noEmit` flag is already present.
+Add the CLI to the project scripts:
+
+```json
+{
+  "scripts": {
+    "check": "resultar-check"
+  }
+}
+```
+
+Run the full project check with:
+
+```sh
+pnpm exec resultar-check
+```
+
+The CLI defaults to `tsconfig.json`, runs TypeScript with no emit, and then applies the configured
+Resultar rules. Use the same project-local TypeScript and plugin configuration for editor
+diagnostics; the setup is described below.
+
+## Add The Full Type-Aware Gate
+
+The CLI quick start is enough to run the default gate. Add the plugin options below when the project
+needs to enable or tune specific type-aware rules. `resultar-check` passes `--noEmit` to TypeScript
+unless a `--noEmit` flag is already present.
 
 Configure the TypeScript plugin and type-aware rules in `tsconfig.json`:
 
@@ -267,6 +243,7 @@ still requires explicit plugin configuration with an absolute or package-root `l
 | `resultar/prefer-and-then`                      | `preferAndThen`                    | Prefer `andThen` / `asyncAndThen` when `map` returns a Resultar value.             |
 | `resultar/typed-catch-mapper`                   | `typedCatchMapper`                 | Require catch conversion helpers to map caught values to typed errors.             |
 | `resultar/no-throw`                             | `noThrow`                          | Disallow `throw` statements so expected failures stay in Resultar error channels.  |
+| `resultar/no-try-catch`                         | `noTryCatch`                       | Disallow project-wide `try/catch`; use typed Resultar catch boundaries instead.    |
 | `resultar/no-await-in-safe-try`                 | `noAwaitInSafeTry`                 | Disallow `await` inside `safeTry`; use `yield*` for Resultar values.               |
 | `resultar/no-unsafe-await`                      | `noUnsafeAwait`                    | Require raw Promise awaits in Resultar async contexts to use Resultar boundaries.  |
 | `resultar/no-try-catch-in-safe-try`             | `noTryCatchInSafeTry`              | Avoid raw `try/catch` inside `safeTry` generators.                                 |
@@ -278,10 +255,13 @@ still requires explicit plugin configuration with an absolute or package-root `l
 | `resultar/no-useless-recovery`                  | `noUselessRecovery`                | Flag recovery calls on `Result<T, never>` / `ResultAsync<T, never>`.               |
 
 Each option accepts `"error"`, `"warning"`, `"suggestion"`, `"message"`, or `"off"`.
-`noThrow` defaults to `"off"` because it is a strict migration rule. Enable it when expected
-domain/application failures should always return `Err`/`errAsync` instead of throwing. It reports all
-`throw` statements in inspected source files, including throws inside `tryResultAsync` boundaries;
-use `ignoreFilePatterns` for test, script, or process-boundary files that intentionally throw.
+`noThrow` and `noTryCatch` default to `"off"` because they are strict migration rules. Enable them
+when expected domain/application failures should always stay in typed Resultar channels.
+`noTryCatch` reports only `try` statements with a `catch`; `try/finally` remains available for
+cleanup. The narrower `noTryCatchInSafeTry` remains enabled by default to protect `safeTry`
+composition. `noThrow` reports all `throw` statements in inspected source files, including throws
+inside `tryResultAsync` boundaries; use `ignoreFilePatterns` for test, script, or process-boundary
+files that intentionally use terminal exception control flow.
 
 `noAwaitInSafeTry` defaults to `"error"` and reports every `await` expression inside an inspectable
 `safeTry` body. Use `yield*` for both `Result` and `ResultAsync` values; wrap raw Promises with a
@@ -334,6 +314,54 @@ Use the AST-only adapters when a lint host should report fast syntax-only Result
 adapters intentionally cover only rules that do not need TypeScript type information; use the
 `resultar-check` CLI with the normal project `tsconfig.json` for the full rule set.
 
+### Quick Start With Oxlint
+
+Install Resultar Check and Oxlint when the project wants an AST-only lint pass:
+
+```sh
+pnpm add -D resultar-check oxlint
+```
+
+Create `oxlint.config.json`:
+
+```json
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "jsPlugins": [
+    {
+      "name": "resultar",
+      "specifier": "./node_modules/resultar-check/dist/eslint/plugin.js"
+    }
+  ],
+  "rules": {
+    "resultar/no-await-in-safe-try": "error",
+    "resultar/no-tagged-error-constructor-override": "error",
+    "resultar/no-throw": "error",
+    "resultar/no-try-catch": "error",
+    "resultar/no-try-catch-in-safe-try": "error",
+    "resultar/prefer-tagged-error": "error",
+    "resultar/tagged-error-name-match": "error",
+    "resultar/typed-catch-mapper": "error",
+    "resultar/yield-star-in-safe-try": "error"
+  }
+}
+```
+
+Add an optional lint script:
+
+```json
+{
+  "scripts": {
+    "lint:resultar": "oxlint --config oxlint.config.json"
+  }
+}
+```
+
+The AST-only rules need no type information. Keep `resultar-check` as the authoritative CLI gate
+for the complete rule set. See the runnable
+[lint adapter example](https://github.com/inaiat/resultar/tree/main/examples/lint) for parity
+checks across Oxlint, ESLint, and the CLI.
+
 The AST-only adapter rules are:
 
 | Rule                                            | Checks                                                |
@@ -341,6 +369,7 @@ The AST-only adapter rules are:
 | `resultar/no-await-in-safe-try`                 | `await` inside `safeTry` bodies                       |
 | `resultar/no-tagged-error-constructor-override` | constructor overrides on `createTaggedError` classes  |
 | `resultar/no-throw`                             | raw `throw` statements                                |
+| `resultar/no-try-catch`                         | project-wide `try/catch` blocks                       |
 | `resultar/no-try-catch-in-safe-try`             | raw `try/catch` inside `safeTry` bodies               |
 | `resultar/prefer-tagged-error`                  | native `Error` classes, `err(new Error(...))`, throws |
 | `resultar/tagged-error-name-match`              | tagged error runtime name and class name mismatch     |
@@ -372,6 +401,7 @@ export default [
       "resultar/no-await-in-safe-try": "error",
       "resultar/no-tagged-error-constructor-override": "error",
       "resultar/no-throw": "error",
+      "resultar/no-try-catch": "error",
       "resultar/no-try-catch-in-safe-try": "error",
       "resultar/prefer-tagged-error": "error",
       "resultar/tagged-error-name-match": "error",
@@ -395,6 +425,7 @@ Deno Lint can load `resultar-check/deno`:
         "resultar/no-await-in-safe-try",
         "resultar/no-tagged-error-constructor-override",
         "resultar/no-throw",
+        "resultar/no-try-catch",
         "resultar/no-try-catch-in-safe-try",
         "resultar/prefer-tagged-error",
         "resultar/tagged-error-name-match",
@@ -433,6 +464,7 @@ extends the normal `tsconfig.json` and turns off type-aware-only rules:
         "noDiscard": "off",
         "noTaggedErrorConstructorOverride": "error",
         "noThrow": "error",
+        "noTryCatch": "error",
         "noTryCatchInSafeTry": "error",
         "noUnsafeAwait": "off",
         "noUselessRecovery": "off",

--- a/packages/check/package.json
+++ b/packages/check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resultar-check",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Resultar diagnostics for TypeScript >=7",
   "keywords": [
     "lint",

--- a/packages/check/schema.json
+++ b/packages/check/schema.json
@@ -76,6 +76,11 @@
           "default": "off",
           "description": "Disallow throw statements so expected failures stay in Resultar error channels."
         },
+        "noTryCatch": {
+          "$ref": "#/definitions/ruleSeverity",
+          "default": "off",
+          "description": "Disallow try/catch blocks so expected failures use typed Resultar boundaries. Try/finally without catch remains allowed."
+        },
         "noTryCatchInSafeTry": {
           "$ref": "#/definitions/ruleSeverity",
           "default": "warning",

--- a/packages/check/src/diagnostics.ts
+++ b/packages/check/src/diagnostics.ts
@@ -16,6 +16,7 @@ export const RESULTAR_RULE_DIAGNOSTIC_CODES: Record<ResultarRuleName, number> = 
   "no-discard": RESULTAR_NO_DISCARD_DIAGNOSTIC_CODE,
   "no-tagged-error-constructor-override": 91_010,
   "no-throw": 91_013,
+  "no-try-catch": 91_015,
   "no-try-catch-in-safe-try": 91_006,
   "no-unsafe-await": 91_012,
   "no-useless-recovery": 91_011,

--- a/packages/check/src/finding.ts
+++ b/packages/check/src/finding.ts
@@ -3,6 +3,7 @@ export type ResultarRuleName =
   | "no-await-in-safe-try"
   | "no-tagged-error-constructor-override"
   | "no-throw"
+  | "no-try-catch"
   | "no-try-catch-in-safe-try"
   | "no-unsafe-await"
   | "no-useless-recovery"

--- a/packages/check/src/plugin-options.ts
+++ b/packages/check/src/plugin-options.ts
@@ -33,6 +33,7 @@ export const parsePluginOptions = (config: unknown): ResultarLanguageServiceOpti
       defaultResultarRulesOptions.noTaggedErrorConstructorOverride,
     ),
     noThrow: normalizeRuleSeverity(config.noThrow, defaultResultarRulesOptions.noThrow),
+    noTryCatch: normalizeRuleSeverity(config.noTryCatch, defaultResultarRulesOptions.noTryCatch),
     noTryCatchInSafeTry: normalizeRuleSeverity(
       config.noTryCatchInSafeTry,
       defaultResultarRulesOptions.noTryCatchInSafeTry,

--- a/packages/check/src/rules-core.ts
+++ b/packages/check/src/rules-core.ts
@@ -72,6 +72,7 @@ export interface ResultarRulesOptions {
   readonly noDiscardMode: NoDiscardMode;
   readonly noTaggedErrorConstructorOverride: ResultarRuleSeverity;
   readonly noThrow: ResultarRuleSeverity;
+  readonly noTryCatch: ResultarRuleSeverity;
   readonly noTryCatchInSafeTry: ResultarRuleSeverity;
   readonly noUnsafeAwait: ResultarRuleSeverity;
   readonly noUnsafeAwaitIgnoreCalls: readonly string[];
@@ -92,6 +93,7 @@ export const resultarRuleNames: readonly ResultarRuleName[] = [
   "prefer-and-then",
   "typed-catch-mapper",
   "no-throw",
+  "no-try-catch",
   "no-await-in-safe-try",
   "no-unsafe-await",
   "no-try-catch-in-safe-try",
@@ -108,6 +110,7 @@ export const ruleOptionNameByRule: Record<ResultarRuleName, ResultarRuleOptionNa
   "no-discard": "noDiscard",
   "no-tagged-error-constructor-override": "noTaggedErrorConstructorOverride",
   "no-throw": "noThrow",
+  "no-try-catch": "noTryCatch",
   "no-try-catch-in-safe-try": "noTryCatchInSafeTry",
   "no-unsafe-await": "noUnsafeAwait",
   "no-useless-recovery": "noUselessRecovery",
@@ -127,6 +130,7 @@ export const defaultResultarRulesOptions: ResultarRulesOptions = {
   noDiscardMode: "must-use",
   noTaggedErrorConstructorOverride: "warning",
   noThrow: "off",
+  noTryCatch: "off",
   noTryCatchInSafeTry: "warning",
   noUnsafeAwait: "off",
   noUnsafeAwaitIgnoreCalls: [],
@@ -224,6 +228,7 @@ export const normalizeResultarRulesOptions = (
     defaultResultarRulesOptions.noTaggedErrorConstructorOverride,
   ),
   noThrow: normalizeRuleSeverity(options.noThrow, defaultResultarRulesOptions.noThrow),
+  noTryCatch: normalizeRuleSeverity(options.noTryCatch, defaultResultarRulesOptions.noTryCatch),
   noTryCatchInSafeTry: normalizeRuleSeverity(
     options.noTryCatchInSafeTry,
     defaultResultarRulesOptions.noTryCatchInSafeTry,
@@ -1429,6 +1434,31 @@ const getNoTryCatchInSafeTryFindings = (
   return findings;
 };
 
+const getNoTryCatchFindings = (
+  context: RuleContext,
+  severity: EnabledRuleSeverity,
+): readonly ResultarLintFinding[] => {
+  const findings: ResultarLintFinding[] = [];
+
+  visitSourceFile(context, (node) => {
+    if (!context.tsApi.isTryStatement(node) || node.catchClause === undefined) {
+      return;
+    }
+
+    findings.push(
+      createFinding(
+        context,
+        node,
+        "no-try-catch",
+        severity,
+        "Avoid raw try/catch for expected failures. Use tryResult or tryResultAsync to preserve the typed error channel.",
+      ),
+    );
+  });
+
+  return findings;
+};
+
 const getNoAwaitInSafeTryFindings = (
   context: RuleContext,
   severity: EnabledRuleSeverity,
@@ -1796,6 +1826,7 @@ export const getSourceFileResultarFindings = (
     ["prefer-and-then", getPreferAndThenFindings],
     ["typed-catch-mapper", getTypedCatchMapperFindings],
     ["no-throw", getNoThrowFindings],
+    ["no-try-catch", getNoTryCatchFindings],
     ["no-await-in-safe-try", getNoAwaitInSafeTryFindings],
     ["no-try-catch-in-safe-try", getNoTryCatchInSafeTryFindings],
     ["yield-star-in-safe-try", getYieldStarInSafeTryFindings],

--- a/packages/check/src/rules.ts
+++ b/packages/check/src/rules.ts
@@ -19,6 +19,7 @@ export type ResultarLintRuleName =
   | "no-await-in-safe-try"
   | "no-tagged-error-constructor-override"
   | "no-throw"
+  | "no-try-catch"
   | "no-try-catch-in-safe-try"
   | "prefer-tagged-error"
   | "tagged-error-name-match"
@@ -75,6 +76,20 @@ const noThrow = createRule("Disallow raw throw statements in Resultar code.", (c
     context.report({
       message:
         "Do not throw for expected Resultar failures. Return Err/errAsync or wrap external code with a Resultar catch boundary.",
+      node,
+    });
+  },
+}));
+
+const noTryCatch = createRule("Disallow raw try/catch blocks in Resultar code.", (context) => ({
+  TryStatement(node) {
+    if (!isNode(node.handler) || node.handler.type !== "CatchClause") {
+      return;
+    }
+
+    context.report({
+      message:
+        "Avoid raw try/catch for expected failures. Use tryResult or tryResultAsync to preserve the typed error channel.",
       node,
     });
   },
@@ -228,6 +243,7 @@ export const rules: Record<ResultarLintRuleName, ResultarRuleModule> = {
   "no-await-in-safe-try": noAwaitInSafeTry,
   "no-tagged-error-constructor-override": noTaggedErrorConstructorOverride,
   "no-throw": noThrow,
+  "no-try-catch": noTryCatch,
   "no-try-catch-in-safe-try": noTryCatchInSafeTry,
   "prefer-tagged-error": preferTaggedError,
   "tagged-error-name-match": taggedErrorNameMatch,
@@ -239,6 +255,7 @@ export const recommendedSeverities: Record<ResultarLintRuleName, "error" | "warn
   "no-await-in-safe-try": "error",
   "no-tagged-error-constructor-override": "warn",
   "no-throw": "warn",
+  "no-try-catch": "warn",
   "no-try-catch-in-safe-try": "warn",
   "prefer-tagged-error": "warn",
   "tagged-error-name-match": "warn",

--- a/packages/check/tests/ast-rules.test.ts
+++ b/packages/check/tests/ast-rules.test.ts
@@ -68,6 +68,20 @@ describe("resultar-check AST-only rules", () => {
     equal(reports.length, 1);
   });
 
+  it("flags raw try/catch and allows try/finally", () => {
+    const caught = runRule("no-try-catch", "TryStatement", {
+      handler: { type: "CatchClause" },
+      type: "TryStatement",
+    });
+    const finalized = runRule("no-try-catch", "TryStatement", {
+      finalizer: blockStatement([]),
+      type: "TryStatement",
+    });
+
+    equal(caught.length, 1);
+    equal(finalized.length, 0);
+  });
+
   it("flags raw try/catch inside safeTry", () => {
     const reports = runRule(
       "no-try-catch-in-safe-try",
@@ -187,6 +201,7 @@ describe("resultar-check AST-only rules", () => {
       "no-await-in-safe-try",
       "no-tagged-error-constructor-override",
       "no-throw",
+      "no-try-catch",
       "no-try-catch-in-safe-try",
       "prefer-tagged-error",
       "tagged-error-name-match",

--- a/packages/check/tests/lint-cli.test.ts
+++ b/packages/check/tests/lint-cli.test.ts
@@ -132,6 +132,7 @@ describe("lint CLI and integration edges", () => {
       noDiscard: "off",
       noDiscardMode: "direct",
       noThrow: "error",
+      noTryCatch: "suggestion",
       noUnsafeAwaitIgnoreCalls: ["startServer", "fastify.after"],
       noUnsafeAwaitMode: "all",
       preferTaggedError: "suggestion",
@@ -143,6 +144,7 @@ describe("lint CLI and integration edges", () => {
     equal(parsed.noDiscard, "off");
     equal(parsed.noDiscardMode, "direct");
     equal(parsed.noThrow, "error");
+    equal(parsed.noTryCatch, "suggestion");
     deepEqual(parsed.noUnsafeAwaitIgnoreCalls, ["startServer", "fastify.after"]);
     equal(parsed.noUnsafeAwaitMode, "all");
     equal(parsed.preferTaggedError, "suggestion");
@@ -152,12 +154,14 @@ describe("lint CLI and integration edges", () => {
     equal(fallback.noAwaitInSafeTry, defaultResultarRulesOptions.noAwaitInSafeTry);
     equal(fallback.noDiscard, defaultResultarRulesOptions.noDiscard);
     equal(fallback.noThrow, defaultResultarRulesOptions.noThrow);
+    equal(fallback.noTryCatch, defaultResultarRulesOptions.noTryCatch);
 
     const normalized = normalizeResultarRulesOptions({
       ignoreFilePatterns: ["*.test.ts"],
       noAwaitInSafeTry: "message",
       noDiscard: "off",
       noThrow: "warning",
+      noTryCatch: "message",
       noUnsafeAwaitIgnoreCalls: ["startServer", "fastify.after"],
       noUnsafeAwaitMode: "all",
       preferMapErr: "suggestion",
@@ -166,6 +170,7 @@ describe("lint CLI and integration edges", () => {
     equal(normalized.noAwaitInSafeTry, "message");
     equal(normalized.noDiscard, "off");
     equal(normalized.noThrow, "warning");
+    equal(normalized.noTryCatch, "message");
     deepEqual(normalized.noUnsafeAwaitIgnoreCalls, ["startServer", "fastify.after"]);
     equal(normalized.noUnsafeAwaitMode, "all");
     equal(normalized.preferMapErr, "suggestion");

--- a/packages/check/tests/resultar-rules.test.ts
+++ b/packages/check/tests/resultar-rules.test.ts
@@ -174,6 +174,15 @@ describe("Resultar lint rules", () => {
           throw error
         `,
       },
+      "no-try-catch": {
+        source: `
+          try {
+            JSON.parse("{}")
+          } catch {
+            // Expected failures should use a typed Resultar boundary.
+          }
+        `,
+      },
       "no-await-in-safe-try": {
         source: `
           declare function loadUser(): Promise<string>
@@ -730,6 +739,33 @@ describe("Resultar lint rules", () => {
 
     equal(findings.length, 1);
     equal(findings[0]?.rule, "no-try-catch-in-safe-try");
+  });
+
+  it("flags project-wide try/catch but allows try/finally", async () => {
+    const caught = await runRule(
+      "no-try-catch",
+      `
+        try {
+          JSON.parse("{}")
+        } catch {
+          // Expected failures should use a typed Resultar boundary.
+        }
+      `,
+    );
+    const finalized = await runRule(
+      "no-try-catch",
+      `
+        try {
+          console.log("work")
+        } finally {
+          console.log("cleanup")
+        }
+      `,
+    );
+
+    equal(caught.length, 1);
+    equal(caught[0]?.rule, "no-try-catch");
+    deepEqual(finalized, []);
   });
 
   it("flags try/catch inside safeTry object methods", async () => {

--- a/packages/request-typebox/README.md
+++ b/packages/request-typebox/README.md
@@ -5,6 +5,11 @@ TypeBox adapter for `resultar-request`.
 Use this package when a request response should be validated with TypeBox while the transport and
 Resultar error flow stay in `resultar-request`.
 
+For a schema-library-agnostic request, use [`resultar-request`](../request/README.md) directly with
+its `validator` or `decode` options. The sibling
+[`resultar-request-zod`](../request-zod/README.md) package provides the same request flow with Zod
+schemas instead of TypeBox.
+
 ## Install
 
 ```sh
@@ -18,24 +23,66 @@ npm install resultar-request-typebox typebox
 ## `requestJson`
 
 ```ts
-import { requestJson } from 'resultar-request-typebox'
+import { createTaggedError } from 'resultar'
+import {
+  requestJson as requestJsonTypeBox,
+  type RequestJsonMapError,
+} from 'resultar-request-typebox'
 import { Type, type Static } from 'typebox'
 
-const userSchema = Type.Object({
-  id: Type.String(),
-  email: Type.String(),
-})
+const userSchema = Type.Object(
+  {
+    id: Type.String(),
+    email: Type.String(),
+    plan: Type.Union([Type.Literal('free'), Type.Literal('team')]),
+  },
+  { additionalProperties: false },
+)
 
 type User = Static<typeof userSchema>
 
-const user = requestJson({
+class UserApiError extends createTaggedError({
+  name: 'UserApiError',
+  message: 'User API $reason: $detail',
+}) {}
+
+const mapUserError = {
+  404: ({ statusCode }) =>
+    new UserApiError({ reason: 'not-found', detail: `HTTP ${statusCode}` }),
+  http: ({ statusCode }) =>
+    new UserApiError({ reason: 'http', detail: `HTTP ${statusCode}` }),
+  invalidJson: ({ cause }) =>
+    new UserApiError({ cause, reason: 'invalid-json', detail: cause.message }),
+  request: ({ cause }) =>
+    new UserApiError({ cause, reason: 'request', detail: cause.message }),
+  validation: ({ errors }) =>
+    new UserApiError({
+      reason: 'validation',
+      detail: `${errors.length} validation issue(s)`,
+    }),
+} satisfies RequestJsonMapError
+
+const user = requestJsonTypeBox({
   request: () => fetch('https://example.com/users/123'),
   schema: userSchema,
+  mapError: mapUserError,
 })
+
+const userLabel = user.map(({ email, plan }) => `${email} (${plan})`)
 ```
 
-The returned type is `ResultAsync<User, RequestError>`. `requestJsonTypeBox` is exported as the
-named adapter helper, and `requestJson` is an alias for package-local ergonomics.
+`Static<typeof userSchema>` is the success type, so the request returns
+`ResultAsync<User, UserApiError>` in this example. TypeBox validates the unknown JSON response at
+runtime, while Resultar keeps request, HTTP, invalid-JSON, and validation failures in the error
+channel. `requestJsonTypeBox` is the named adapter helper, and `requestJson` is an alias for
+package-local ergonomics.
 
 The package also re-exports the public `resultar-request` API, including `RequestError`, map-error
 types, retry types, and structural response types.
+
+The TypeBox and Zod adapters share the same transport behavior: the adapter supplies schema
+validation, while `resultar-request` handles Fetch-compatible responses, JSON errors, retries, and
+Resultar error mapping.
+
+For a runnable server-backed version of this flow, see the
+[request example](../../examples/request/README.md).

--- a/packages/request-zod/README.md
+++ b/packages/request-zod/README.md
@@ -5,6 +5,11 @@ Zod adapter for `resultar-request`.
 Use this package when a request response should be parsed with Zod while the transport and Resultar
 error flow stay in `resultar-request`.
 
+For a schema-library-agnostic request, use [`resultar-request`](../request/README.md) directly with
+its `validator` or `decode` options. The sibling
+[`resultar-request-typebox`](../request-typebox/README.md) package provides the same request flow
+with TypeBox schemas instead of Zod.
+
 ## Install
 
 ```sh
@@ -18,25 +23,56 @@ npm install resultar-request-zod zod
 ## `requestJson`
 
 ```ts
-import { requestJson } from 'resultar-request-zod'
+import type { ResultAsync } from 'resultar'
+import {
+  requestJson as requestJsonZod,
+  type RequestError,
+} from 'resultar-request-zod'
 import { z } from 'zod'
 
-const userSchema = z.object({
-  id: z.string(),
-  email: z.string().email(),
-})
+const userSchema = z
+  .object({
+    id: z.string(),
+    email: z.string().email(),
+    plan: z.enum(['free', 'team']),
+    seats: z.number().int().nonnegative(),
+  })
+  .transform((user) => ({
+    ...user,
+    email: user.email.toLowerCase(),
+    seatLabel: `${user.seats} seats`,
+  }))
 
-const user = requestJson({
+type User = z.output<typeof userSchema>
+
+const user: ResultAsync<User, RequestError> = requestJsonZod({
   request: () => fetch('https://example.com/users/123'),
   schema: userSchema,
+  retry: {
+    times: 2,
+    delayMs: ({ nextAttempt }) => nextAttempt * 100,
+  },
+  validationError: ({ errors }) =>
+    `User response failed validation with ${errors.length} issue(s)`,
 })
+
+const userLabel = user.map(({ email, seatLabel }) => `${email} (${seatLabel})`)
 ```
 
-The returned type is `ResultAsync<z.output<typeof userSchema>, RequestError>`. Zod transforms are
-preserved because the adapter returns parsed output, not the original unknown JSON value.
+The returned type is `ResultAsync<User, RequestError>`. Zod validates the unknown JSON response,
+applies the transform, and passes the transformed `z.output<typeof userSchema>` value into the
+Resultar success channel. The request can also retry request or HTTP `5xx` failures without retrying
+invalid JSON or validation failures.
 
 `requestJsonZod` is exported as the named adapter helper, and `requestJson` is an alias for
 package-local ergonomics.
 
 The package also re-exports the public `resultar-request` API, including `RequestError`, map-error
 types, retry types, and structural response types.
+
+The TypeBox and Zod adapters share the same transport behavior: the adapter supplies schema parsing,
+while `resultar-request` handles Fetch-compatible responses, JSON errors, retries, and Resultar
+error mapping.
+
+For a runnable server-backed version of this flow, see the
+[request example](../../examples/request/README.md).

--- a/packages/request/README.md
+++ b/packages/request/README.md
@@ -42,6 +42,28 @@ const user = requestJson({
 The core package accepts Fetch `Response` objects and Undici-shaped response objects structurally.
 It does not import `undici`, `typebox`, `zod`, or `node:*` at runtime.
 
+## Schema Adapters
+
+`resultar-request` is the schema-library-agnostic core. Use its `validator` or `decode` options when
+you already have a custom type guard or decoder. When the response contract is described by a
+schema library, use one of the optional adapters instead:
+
+- [`resultar-request-typebox`](../request-typebox/README.md) validates responses with TypeBox and
+  derives the success type with `Static<typeof schema>`.
+- [`resultar-request-zod`](../request-zod/README.md) parses responses with Zod and preserves the
+  schema's transformed `z.output<typeof schema>` type.
+
+Both adapters use this package for transport, JSON parsing, retries, and error mapping. They also
+re-export the public request API, so you can keep using `RequestError`, retry types, and map-error
+types from the adapter package.
+
+Install the adapter and its peer schema library together:
+
+```sh
+pnpm add resultar-request-typebox typebox
+pnpm add resultar-request-zod zod
+```
+
 ## Decode
 
 Use `decode` when validation should also transform the payload.

--- a/packages/resultar/README.md
+++ b/packages/resultar/README.md
@@ -58,6 +58,24 @@ pnpm add resultar
 npm install resultar
 ```
 
+## HTTP Request Helpers
+
+Use the core [`resultar-request`](../request/README.md) package for Fetch-first JSON calls that
+should return `ResultAsync` values with typed request, HTTP, JSON, validation, and retry failures.
+The core request package is schema-library agnostic and accepts a custom `validator` or `decode`
+function.
+
+When response contracts already use a schema library, choose the matching optional adapter:
+
+- [`resultar-request-typebox`](../request-typebox/README.md) validates TypeBox schemas and derives
+  the success type with `Static<typeof schema>`.
+- [`resultar-request-zod`](../request-zod/README.md) parses Zod schemas and preserves transformed
+  `z.output<typeof schema>` values.
+
+The adapters delegate transport, JSON parsing, retries, and Resultar error mapping to
+[`resultar-request`](../request/README.md), and re-export its public request types. Install only the
+request package and schema adapter your service needs.
+
 ## Requirements
 
 - Node.js 24+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,29 +16,32 @@ catalogs:
       specifier: 26.1.0
       version: 26.1.0
     '@vitest/coverage-v8':
-      specifier: 4.1.9
-      version: 4.1.9
+      specifier: 4.1.10
+      version: 4.1.10
     '@vitest/ui':
-      specifier: 4.1.9
-      version: 4.1.9
+      specifier: 4.1.10
+      version: 4.1.10
     fallow:
-      specifier: 3.3.0
-      version: 3.3.0
+      specifier: 3.5.0
+      version: 3.5.0
+    oxlint:
+      specifier: 1.74.0
+      version: 1.74.0
     tsx:
-      specifier: 4.22.5
-      version: 4.22.5
+      specifier: 4.23.0
+      version: 4.23.0
     typebox:
-      specifier: 1.3.3
-      version: 1.3.3
+      specifier: 1.3.4
+      version: 1.3.4
     typescript:
       specifier: 7.0.2
       version: 7.0.2
     vite-plus:
-      specifier: 0.2.3
-      version: 0.2.3
+      specifier: 0.2.4
+      version: 0.2.4
     vitest:
-      specifier: 4.1.9
-      version: 4.1.9
+      specifier: 4.1.10
+      version: 4.1.10
     zod:
       specifier: 4.4.3
       version: 4.4.3
@@ -81,11 +84,11 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0
       oxlint:
-        specifier: 1.72.0
-        version: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)))
+        specifier: 'catalog:'
+        version: 1.74.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)))
       tsx:
         specifier: 'catalog:'
-        version: 4.22.5
+        version: 4.23.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -112,14 +115,14 @@ importers:
         specifier: 10.6.0
         version: 10.6.0
       oxlint:
-        specifier: 1.72.0
-        version: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)))
+        specifier: 'catalog:'
+        version: 1.74.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)))
       resultar-check:
         specifier: workspace:*
         version: link:../../packages/check
       tsx:
         specifier: 'catalog:'
-        version: 4.22.5
+        version: 4.23.0
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -143,7 +146,7 @@ importers:
         version: link:../../packages/request-zod
       typebox:
         specifier: 'catalog:'
-        version: 1.3.3
+        version: 1.3.4
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -153,7 +156,7 @@ importers:
         version: 26.1.0
       tsx:
         specifier: 'catalog:'
-        version: 4.22.5
+        version: 4.23.0
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -172,7 +175,7 @@ importers:
         version: 26.1.0
       tsx:
         specifier: 'catalog:'
-        version: 4.22.5
+        version: 4.23.0
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -188,19 +191,19 @@ importers:
         version: 26.1.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.10(vitest@4.1.10)
       fallow:
         specifier: 'catalog:'
-        version: 3.3.0
+        version: 3.5.0
       tsx:
         specifier: 'catalog:'
-        version: 4.22.5
+        version: 4.23.0
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+        version: 0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
 
   packages/request:
     dependencies:
@@ -213,25 +216,25 @@ importers:
         version: 26.1.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.10(vitest@4.1.10)
       fallow:
         specifier: 'catalog:'
-        version: 3.3.0
+        version: 3.5.0
       tsx:
         specifier: 'catalog:'
-        version: 4.22.5
+        version: 4.23.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+        version: 0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+        version: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
 
   packages/request-typebox:
     dependencies:
@@ -247,28 +250,28 @@ importers:
         version: 26.1.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.10(vitest@4.1.10)
       fallow:
         specifier: 'catalog:'
-        version: 3.3.0
+        version: 3.5.0
       tsx:
         specifier: 'catalog:'
-        version: 4.22.5
+        version: 4.23.0
       typebox:
         specifier: 'catalog:'
-        version: 1.3.3
+        version: 1.3.4
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+        version: 0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+        version: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
 
   packages/request-zod:
     dependencies:
@@ -284,25 +287,25 @@ importers:
         version: 26.1.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.10(vitest@4.1.10)
       fallow:
         specifier: 'catalog:'
-        version: 3.3.0
+        version: 3.5.0
       tsx:
         specifier: 'catalog:'
-        version: 4.22.5
+        version: 4.23.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+        version: 0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+        version: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -314,31 +317,31 @@ importers:
         version: 9.6.1(@types/node@26.1.0)
       '@stryker-mutator/vitest-runner':
         specifier: 'catalog:'
-        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@26.1.0))(vitest@4.1.9)
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@26.1.0))(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.10(vitest@4.1.10)
       fallow:
         specifier: 'catalog:'
-        version: 3.3.0
+        version: 3.5.0
       tsx:
         specifier: 'catalog:'
-        version: 4.22.5
+        version: 4.23.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+        version: 0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+        version: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
 
 packages:
 
@@ -835,43 +838,43 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@fallow-cli/darwin-arm64@3.3.0':
-    resolution: {integrity: sha512-QAABM8MzV9P5JCJZHnenxTosqjuWur+w+owlS3cIrG4LqHRPSW1/4C2wJ5z1Q7vKIe4f+O2TuW2yOLwExFrDyQ==}
+  '@fallow-cli/darwin-arm64@3.5.0':
+    resolution: {integrity: sha512-giXY3rGcXIwFvwypdGIpIZEpKefIEmUSAh9KYZh3gb3m4yVxk4KJmwYOhSiVKFfRgTkwQBmnKwtAqnMXATx6SA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@fallow-cli/darwin-x64@3.3.0':
-    resolution: {integrity: sha512-jc5k6nWfDwF8DW0+3m8BNWAFu7l0K6sIkDtPN/IlYvw3iNgBhYyAJlzsugTppuBNvbL2QisqOaa0h4lehdJmJA==}
+  '@fallow-cli/darwin-x64@3.5.0':
+    resolution: {integrity: sha512-vm3y4eGHRXF9ikgV2CH5GhFFBphrZ8RJkOt0Y4pa2WBSYRB5531siYSt+CF970mk/k3ZNAIzEBnRpn9nnggZ6g==}
     cpu: [x64]
     os: [darwin]
 
-  '@fallow-cli/linux-arm64-gnu@3.3.0':
-    resolution: {integrity: sha512-AhOo9+L20GOeljbzK5kgrjv/BXP7esvR2jEpcg2p1PgkbY2NB23jFfEEJGdWsL0kf4V6Gyq3adtTieLSDFJ3YQ==}
+  '@fallow-cli/linux-arm64-gnu@3.5.0':
+    resolution: {integrity: sha512-YbdrnwF4WBgO3v9ynesjyFmo7sVZcryMmH7ClqeNF3zyegx1Lu214NLVQvI/TmuVrLOvmbmslHlZhRb5gsBC7Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@fallow-cli/linux-arm64-musl@3.3.0':
-    resolution: {integrity: sha512-bG/6fD1jMf7x0XOkDyKSSGB3RYCIbZIXjpCyrmFm7icAMJBpZbD6v+JsEjnHezsBox83AduT9GKL6jDEhUlpOQ==}
+  '@fallow-cli/linux-arm64-musl@3.5.0':
+    resolution: {integrity: sha512-cUKfyDpDoViPpZ2A4UREHsRwD+IErdZ/KXjSAsS6s7EBX9AkQkWMBUHcqI4xa4oM5TU0Co6UV7ym8TrUl2FZVQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@fallow-cli/linux-x64-gnu@3.3.0':
-    resolution: {integrity: sha512-N29jZebN880Vgl2MGFlykiBM+jdy95sEJNwBVIjp4HnvWDvr5IavDsPI6bW4eTy8ccij4OJ12IRUlouBtR4cZQ==}
+  '@fallow-cli/linux-x64-gnu@3.5.0':
+    resolution: {integrity: sha512-Jm/3HT15HmEXDc1s6/l33kV3InEZCjWarhOpkV8bybttEM+ezVCgEmF/8fAtjkzowoj14rUj+M3LTFYKDTNZLg==}
     cpu: [x64]
     os: [linux]
 
-  '@fallow-cli/linux-x64-musl@3.3.0':
-    resolution: {integrity: sha512-4I9X01ZpBTSPBZFpI5V1fogu6AGKyF4FsmA5bStop3jnes9kmJlxjSCCCaaO9gLUGZ6Lfh8/j7vu2AN1uNPY8A==}
+  '@fallow-cli/linux-x64-musl@3.5.0':
+    resolution: {integrity: sha512-EB6UPVy9fOsMR4M8Buwg++qQDeMoq22dPu0v77AmELMLN10eWF+Fa6xSSQb0IU4aFOrDm2yjL8C5Z1freqHWRQ==}
     cpu: [x64]
     os: [linux]
 
-  '@fallow-cli/win32-arm64-msvc@3.3.0':
-    resolution: {integrity: sha512-ATaWkzs9+jO+AZYDv5LhTnIuv4qzLjI5l7gGWNWrp7frPWe737w7IgDXnxeQNmmNds5NygKYYMUxS6VoLANUnw==}
+  '@fallow-cli/win32-arm64-msvc@3.5.0':
+    resolution: {integrity: sha512-KQauVmXnhO5UhJJIkU34E/YllLRa1ubWQWyCnzronnNE4QXctChHJ/C5c+PmEA57syLLjhA9rqjdiVB/Xzt5LA==}
     cpu: [arm64]
     os: [win32]
 
-  '@fallow-cli/win32-x64-msvc@3.3.0':
-    resolution: {integrity: sha512-u1SVmKFJeSZyfIKjX85sZ7C+GQe/0TcXSaanD5cdFM9GVmEXrHa4cGFjtQVh7u6Up34iSmYXCNJi0DdUkIvhJA==}
+  '@fallow-cli/win32-x64-msvc@3.5.0':
+    resolution: {integrity: sha512-NsC3KwjaynZSZGq+JPHERi/m2NaUTlTrXJfSS4Z6jeyj7Ihv8fmJ98Gm4mbxwnl01g+RR16pod/urgX/Bhi1mw==}
     cpu: [x64]
     os: [win32]
 
@@ -1246,8 +1249,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@oxlint/binding-android-arm-eabi@1.74.0':
+    resolution: {integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxlint/binding-android-arm64@1.72.0':
     resolution: {integrity: sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.74.0':
+    resolution: {integrity: sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -1258,8 +1273,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxlint/binding-darwin-arm64@1.74.0':
+    resolution: {integrity: sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxlint/binding-darwin-x64@1.72.0':
     resolution: {integrity: sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.74.0':
+    resolution: {integrity: sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -1270,8 +1297,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxlint/binding-freebsd-x64@1.74.0':
+    resolution: {integrity: sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxlint/binding-linux-arm-gnueabihf@1.72.0':
     resolution: {integrity: sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
+    resolution: {integrity: sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1282,8 +1321,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+    resolution: {integrity: sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxlint/binding-linux-arm64-gnu@1.72.0':
     resolution: {integrity: sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-gnu@1.74.0':
+    resolution: {integrity: sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1296,8 +1348,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-linux-arm64-musl@1.74.0':
+    resolution: {integrity: sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxlint/binding-linux-ppc64-gnu@1.72.0':
     resolution: {integrity: sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
+    resolution: {integrity: sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1310,8 +1376,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+    resolution: {integrity: sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-riscv64-musl@1.72.0':
     resolution: {integrity: sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-riscv64-musl@1.74.0':
+    resolution: {integrity: sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -1324,8 +1404,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+    resolution: {integrity: sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-x64-gnu@1.72.0':
     resolution: {integrity: sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.74.0':
+    resolution: {integrity: sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1338,8 +1432,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-linux-x64-musl@1.74.0':
+    resolution: {integrity: sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxlint/binding-openharmony-arm64@1.72.0':
     resolution: {integrity: sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-openharmony-arm64@1.74.0':
+    resolution: {integrity: sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1350,14 +1457,32 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+    resolution: {integrity: sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@oxlint/binding-win32-ia32-msvc@1.72.0':
     resolution: {integrity: sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
+  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+    resolution: {integrity: sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxlint/binding-win32-x64-msvc@1.72.0':
     resolution: {integrity: sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.74.0':
+    resolution: {integrity: sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1669,30 +1794,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitest/browser-preview@4.1.9':
-    resolution: {integrity: sha512-a4/OrkMDb/WUnE4OOB/4FJbK3rYVO7YykqtUgcTKG4p2a0R3XcjPVu7SLRHFBs2+NIYhv5yxp1Lz3dbdGBjIow==}
+  '@vitest/browser-preview@4.1.10':
+    resolution: {integrity: sha512-14MJrL59ZFkqXLjwfSk6RzTDy5Czf9UG4+8q8L6Gxjs2aPjEce/cVNYV14bXAc2BvMjUNu904+ZEZA1Xc1wtvQ==}
     peerDependencies:
-      vitest: 4.1.9
+      vitest: 4.1.10
 
-  '@vitest/browser@4.1.9':
-    resolution: {integrity: sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==}
+  '@vitest/browser@4.1.10':
+    resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
     peerDependencies:
-      vitest: 4.1.9
+      vitest: 4.1.10
 
-  '@vitest/coverage-v8@4.1.9':
-    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
-      '@vitest/browser': 4.1.9
-      vitest: 4.1.9
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.9':
-    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@4.1.9':
-    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1702,28 +1827,28 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.9':
-    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@4.1.9':
-    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@4.1.9':
-    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@4.1.9':
-    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/ui@4.1.9':
-    resolution: {integrity: sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==}
+  '@vitest/ui@4.1.10':
+    resolution: {integrity: sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q==}
     peerDependencies:
-      vitest: 4.1.9
+      vitest: 4.1.10
 
-  '@vitest/utils@4.1.9':
-    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
-  '@voidzero-dev/vite-plus-core@0.2.3':
-    resolution: {integrity: sha512-ObavWwyDQOy7/P0vwCPo6HNg0Wfi9e/Y+D9q6iqrEoxBU7WfMrwuiiExVwJpJsTALRXR3U31etlHbOQXt+otSg==}
+  '@voidzero-dev/vite-plus-core@0.2.4':
+    resolution: {integrity: sha512-AoAYGPwNO56o9TuCR+KaQGA5XpSnTpn2QYHK0DQ0f8j3wvaMmToeWOJF6STo+XMntMDfiaB7sOsSFNE+hPYyjg==}
     engines: {node: ^20.19.0 || ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
@@ -1779,54 +1904,54 @@ packages:
       yaml:
         optional: true
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.2.3':
-    resolution: {integrity: sha512-k8RBnsutZltnIgD60xpOX/pZC6dReJltZOOAJlcjytT1xJT45WUVfbQ9Yqp2ig9Npjn2YIgyJ/E4T8vbCYcZGw==}
+  '@voidzero-dev/vite-plus-darwin-arm64@0.2.4':
+    resolution: {integrity: sha512-UQwoLpnBW3qLqj5H3airPQeMCX3kfffVDM2EYGe889Fn5dOS9VhikuWloJlcjwtKwqLbFqkrsGjfb6XRvuLozg==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.2.3':
-    resolution: {integrity: sha512-9uIf4p6FzV7bTCJ9q10sgXHSZ0/0vWKG/utM79xfSPwFa+wpKtGErPYOEcl0Sq20Kr/T6PV0D1TOlxwi34jEzQ==}
+  '@voidzero-dev/vite-plus-darwin-x64@0.2.4':
+    resolution: {integrity: sha512-f4XtiA4cBc/Z260QvvXIlBqTb/dZMAioohQDoR5jLG9o9vIOaWE2Ujm/zcWDyNpyZ88RLRrcO8ZwiMrEsdzbJw==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.3':
-    resolution: {integrity: sha512-eFurt6lOf4iHpNdZZhjJl0uLMAeRhGAdl1M7CCqX+ZGErb4E0QWWb9ylUn83e6GmJ86l9D511szE8P6EcEepjQ==}
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.4':
+    resolution: {integrity: sha512-TUamG9wEehZI4SFG7M6nUKb6z/7x3nNOBbnPdWIpv4C8uWKHwNtsnaaVLeygHIUIJEhbByR3oEFDylYLLr4KRw==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@voidzero-dev/vite-plus-linux-arm64-musl@0.2.3':
-    resolution: {integrity: sha512-LhKllbXEUuhxfnPD/KP0MBbbIHjjCy591FEr2wlyTodfUHkku+lpfWEe9OByB1yfMbHpTHXdKeZovPI7mQhbOw==}
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.2.4':
+    resolution: {integrity: sha512-CS9uQ22QFr+lZZp95Huccg3cip3QYVU9GWrhvATqMBXWXb8IRHOulzuXrFxzvhMBITyPaRS9m/eIHmnM4L4h4Q==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.2.3':
-    resolution: {integrity: sha512-XRbQngrET+P+kE1pHf6/g/oUC7mT5hFxZh7ESH7SlcMMnQgPyck4PifBP4M56Bksc08K3iezu0QZU046PHM/6g==}
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.2.4':
+    resolution: {integrity: sha512-X5XfvftFERjer78SG+QKaJCa9LgIKygx4w13sD1/RS/kYOtaf1+yifrJpOFel+t9TRe/YqGTZa5C8uFrDz3OHw==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@voidzero-dev/vite-plus-linux-x64-musl@0.2.3':
-    resolution: {integrity: sha512-0DLtmg5DB1ePYceotaTnhXvWuTYTwmwJ6BvRji033I7yugNkaGsChuu/bB/R+7NFhzejMhA8I4gniG1Qjm2MtA==}
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.2.4':
+    resolution: {integrity: sha512-2iIWW6JR0UOK4QIFKgUQHjaF/7hZxELePny8R1OIn2jzShRfQhS1cmxksSg8ce/5nhYrfQ9dkg5ZmdLbxhpS/A==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.3':
-    resolution: {integrity: sha512-69DG5DtHuaWlHmu3f8+Aqop4QF/5UF7PvoS+bMkUBSTsLJqW6MaVegRg9SrSeqlnC/5mS9CkUPU/7btRO/BJeQ==}
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.4':
+    resolution: {integrity: sha512-3yY4FnpvKBxjmHtEcao6Wcs/VBstzC0GhXAPWetbiFEl/sgL66V4Uhws02esfOSWw8abqLrXyPE9vK+newtsuw==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.2.3':
-    resolution: {integrity: sha512-+rqNdy3Iimm5/cwPiIpPmucQd7+A3Y7lVRkH5LrOT1TDdpZMx/HpSYiFgb1PXj9jy9V4RaNxfiG0uv6t3o8+pA==}
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.2.4':
+    resolution: {integrity: sha512-ERnFrh1O0XZhmGSqND04jtHM7tyKaGAOeT1w/HpVFmL/cQK2vuLl2GKjEwOqkBLd2csNGCcnk3e7C2qDmrNR/Q==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [win32]
@@ -2122,9 +2247,9 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
-  fallow@3.3.0:
-    resolution: {integrity: sha512-R26TBsoJaZw3hUN1FD8HlLfU4peTwxgED7aMh5ho7H4U/LqgZsxCQmchljCQp9J8kpvI1EtUINvOSp6woXtvRw==}
-    engines: {node: '>=16'}
+  fallow@3.5.0:
+    resolution: {integrity: sha512-bE8C0ZAXy7TFARtvycS/B/XLlLFIQf71AxKNXHiDqHFuvXuP9fvaioMwUQXM5INHMNX94j+N+8WkYw2CYXLaXg==}
+    engines: {node: '>=22'}
     hasBin: true
 
   fast-deep-equal@3.1.3:
@@ -2617,6 +2742,19 @@ packages:
       vite-plus:
         optional: true
 
+  oxlint@1.74.0:
+    resolution: {integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.24.0'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -2904,8 +3042,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.22.5:
-    resolution: {integrity: sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==}
+  tsx@4.23.0:
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2917,8 +3055,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typebox@1.3.3:
-    resolution: {integrity: sha512-URXGUE31PJDQC+PtRMJeLdF4kmmOdFoVPikPCtV2oOIhUpNpppEdIz7W8bH8cFYPYHdDpaRvqwdegMTmHliudg==}
+  typebox@1.3.4:
+    resolution: {integrity: sha512-j3MCKfJMIHdrr4ZQMzaJnvXrUbMNuncwssmQkny3Cv5vxrDE1o1WhZFEqGSlU884xtYS5sAa3O/XsUPbUbPWKQ==}
 
   typed-inject@5.0.0:
     resolution: {integrity: sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==}
@@ -2961,13 +3099,13 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  vite-plus@0.2.3:
-    resolution: {integrity: sha512-Rv2jyRNpvZR8MlxJJTmQXrt6VdRSe8Yw9QI1ZzMt5rKMPFAGhnMMktRMjfuZpgnRA+d5eY7g72Ypp2AjV74lyQ==}
+  vite-plus@0.2.4:
+    resolution: {integrity: sha512-gaBBjOXIq9lLRU44oAYdIr99p+JBLX1kxs+l/6LqGgSXwcVKAdDa1boSrOTELqYCkQQ0fpppXUGWi9o6JDT5zw==}
     engines: {node: ^20.19.0 || ^22.18.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
-      '@vitest/browser-playwright': 4.1.9
-      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
     peerDependenciesMeta:
       '@vitest/browser-playwright':
         optional: true
@@ -3017,20 +3155,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.9:
-    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.9
-      '@vitest/browser-preview': 4.1.9
-      '@vitest/browser-webdriverio': 4.1.9
-      '@vitest/coverage-istanbul': 4.1.9
-      '@vitest/coverage-v8': 4.1.9
-      '@vitest/ui': 4.1.9
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3692,28 +3830,28 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@fallow-cli/darwin-arm64@3.3.0':
+  '@fallow-cli/darwin-arm64@3.5.0':
     optional: true
 
-  '@fallow-cli/darwin-x64@3.3.0':
+  '@fallow-cli/darwin-x64@3.5.0':
     optional: true
 
-  '@fallow-cli/linux-arm64-gnu@3.3.0':
+  '@fallow-cli/linux-arm64-gnu@3.5.0':
     optional: true
 
-  '@fallow-cli/linux-arm64-musl@3.3.0':
+  '@fallow-cli/linux-arm64-musl@3.5.0':
     optional: true
 
-  '@fallow-cli/linux-x64-gnu@3.3.0':
+  '@fallow-cli/linux-x64-gnu@3.5.0':
     optional: true
 
-  '@fallow-cli/linux-x64-musl@3.3.0':
+  '@fallow-cli/linux-x64-musl@3.5.0':
     optional: true
 
-  '@fallow-cli/win32-arm64-msvc@3.3.0':
+  '@fallow-cli/win32-arm64-msvc@3.5.0':
     optional: true
 
-  '@fallow-cli/win32-x64-msvc@3.3.0':
+  '@fallow-cli/win32-x64-msvc@3.5.0':
     optional: true
 
   '@humanfs/core@0.19.2':
@@ -3996,58 +4134,115 @@ snapshots:
   '@oxlint/binding-android-arm-eabi@1.72.0':
     optional: true
 
+  '@oxlint/binding-android-arm-eabi@1.74.0':
+    optional: true
+
   '@oxlint/binding-android-arm64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.74.0':
     optional: true
 
   '@oxlint/binding-darwin-arm64@1.72.0':
     optional: true
 
+  '@oxlint/binding-darwin-arm64@1.74.0':
+    optional: true
+
   '@oxlint/binding-darwin-x64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.74.0':
     optional: true
 
   '@oxlint/binding-freebsd-x64@1.72.0':
     optional: true
 
+  '@oxlint/binding-freebsd-x64@1.74.0':
+    optional: true
+
   '@oxlint/binding-linux-arm-gnueabihf@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
     optional: true
 
   '@oxlint/binding-linux-arm-musleabihf@1.72.0':
     optional: true
 
+  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+    optional: true
+
   '@oxlint/binding-linux-arm64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.74.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-musl@1.72.0':
     optional: true
 
+  '@oxlint/binding-linux-arm64-musl@1.74.0':
+    optional: true
+
   '@oxlint/binding-linux-ppc64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-gnu@1.72.0':
     optional: true
 
+  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+    optional: true
+
   '@oxlint/binding-linux-riscv64-musl@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.74.0':
     optional: true
 
   '@oxlint/binding-linux-s390x-gnu@1.72.0':
     optional: true
 
+  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+    optional: true
+
   '@oxlint/binding-linux-x64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.74.0':
     optional: true
 
   '@oxlint/binding-linux-x64-musl@1.72.0':
     optional: true
 
+  '@oxlint/binding-linux-x64-musl@1.74.0':
+    optional: true
+
   '@oxlint/binding-openharmony-arm64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.74.0':
     optional: true
 
   '@oxlint/binding-win32-arm64-msvc@1.72.0':
     optional: true
 
+  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+    optional: true
+
   '@oxlint/binding-win32-ia32-msvc@1.72.0':
     optional: true
 
+  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+    optional: true
+
   '@oxlint/binding-win32-x64-msvc@1.72.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.74.0':
     optional: true
 
   '@oxlint/plugins@1.68.0': {}
@@ -4173,14 +4368,14 @@ snapshots:
 
   '@stryker-mutator/util@9.6.1': {}
 
-  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@26.1.0))(vitest@4.1.9)':
+  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@26.1.0))(vitest@4.1.10)':
     dependencies:
       '@stryker-mutator/api': 9.6.1
       '@stryker-mutator/core': 9.6.1(@types/node@26.1.0)
       '@stryker-mutator/util': 9.6.1
       semver: 7.8.4
       tslib: 2.8.1
-      vitest: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4287,28 +4482,28 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vitest/browser-preview@4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))(vitest@4.1.9)':
+  '@vitest/browser-preview@4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))(vitest@4.1.10)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))(vitest@4.1.9)
-      vitest: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+      '@vitest/browser': 4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))(vitest@4.1.10)
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))(vitest@4.1.9)':
+  '@vitest/browser@4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
-      '@vitest/utils': 4.1.9
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -4316,10 +4511,10 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)':
+  '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       ast-v8-to-istanbul: 1.0.4
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -4328,63 +4523,63 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))(vitest@4.1.9)
+      '@vitest/browser': 4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))(vitest@4.1.10)
 
-  '@vitest/expect@4.1.9':
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))':
+  '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))':
     dependencies:
-      '@vitest/spy': 4.1.9
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)
+      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)
 
-  '@vitest/pretty-format@4.1.9':
+  '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.9':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.9':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.9': {}
+  '@vitest/spy@4.1.10': {}
 
-  '@vitest/ui@4.1.9(vitest@4.1.9)':
+  '@vitest/ui@4.1.10(vitest@4.1.10)':
     dependencies:
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       fflate: 0.8.3
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
 
-  '@vitest/utils@4.1.9':
+  '@vitest/utils@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
+      '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.2.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)':
+  '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)':
     dependencies:
       '@oxc-project/runtime': 0.138.0
       '@oxc-project/types': 0.138.0
@@ -4394,31 +4589,31 @@ snapshots:
       '@types/node': 26.1.0
       esbuild: 0.28.1
       fsevents: 2.3.3
-      tsx: 4.22.5
+      tsx: 4.23.0
       typescript: 7.0.2
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.2.3':
+  '@voidzero-dev/vite-plus-darwin-arm64@0.2.4':
     optional: true
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.2.3':
+  '@voidzero-dev/vite-plus-darwin-x64@0.2.4':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.3':
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.4':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-arm64-musl@0.2.3':
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.2.4':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.2.3':
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.2.4':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-x64-musl@0.2.3':
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.2.4':
     optional: true
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.3':
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.4':
     optional: true
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.2.3':
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.2.4':
     optional: true
 
   acorn-jsx@5.3.2(acorn@8.17.0):
@@ -4728,18 +4923,18 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
-  fallow@3.3.0:
+  fallow@3.5.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      '@fallow-cli/darwin-arm64': 3.3.0
-      '@fallow-cli/darwin-x64': 3.3.0
-      '@fallow-cli/linux-arm64-gnu': 3.3.0
-      '@fallow-cli/linux-arm64-musl': 3.3.0
-      '@fallow-cli/linux-x64-gnu': 3.3.0
-      '@fallow-cli/linux-x64-musl': 3.3.0
-      '@fallow-cli/win32-arm64-msvc': 3.3.0
-      '@fallow-cli/win32-x64-msvc': 3.3.0
+      '@fallow-cli/darwin-arm64': 3.5.0
+      '@fallow-cli/darwin-x64': 3.5.0
+      '@fallow-cli/linux-arm64-gnu': 3.5.0
+      '@fallow-cli/linux-arm64-musl': 3.5.0
+      '@fallow-cli/linux-x64-gnu': 3.5.0
+      '@fallow-cli/linux-x64-musl': 3.5.0
+      '@fallow-cli/win32-arm64-msvc': 3.5.0
+      '@fallow-cli/win32-x64-msvc': 3.5.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -5130,7 +5325,7 @@ snapshots:
 
   outdent@0.5.0: {}
 
-  oxfmt@0.57.0(vite-plus@0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))):
+  oxfmt@0.57.0(vite-plus@0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -5153,7 +5348,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.57.0
       '@oxfmt/binding-win32-ia32-msvc': 0.57.0
       '@oxfmt/binding-win32-x64-msvc': 0.57.0
-      vite-plus: 0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+      vite-plus: 0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
 
   oxlint-tsgolint@0.24.0:
     optionalDependencies:
@@ -5164,7 +5359,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.24.0
       '@oxlint-tsgolint/win32-x64': 0.24.0
 
-  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0
@@ -5186,7 +5381,31 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
       oxlint-tsgolint: 0.24.0
-      vite-plus: 0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+      vite-plus: 0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
+
+  oxlint@1.74.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.74.0
+      '@oxlint/binding-android-arm64': 1.74.0
+      '@oxlint/binding-darwin-arm64': 1.74.0
+      '@oxlint/binding-darwin-x64': 1.74.0
+      '@oxlint/binding-freebsd-x64': 1.74.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.74.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.74.0
+      '@oxlint/binding-linux-arm64-gnu': 1.74.0
+      '@oxlint/binding-linux-arm64-musl': 1.74.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.74.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.74.0
+      '@oxlint/binding-linux-riscv64-musl': 1.74.0
+      '@oxlint/binding-linux-s390x-gnu': 1.74.0
+      '@oxlint/binding-linux-x64-gnu': 1.74.0
+      '@oxlint/binding-linux-x64-musl': 1.74.0
+      '@oxlint/binding-openharmony-arm64': 1.74.0
+      '@oxlint/binding-win32-arm64-msvc': 1.74.0
+      '@oxlint/binding-win32-ia32-msvc': 1.74.0
+      '@oxlint/binding-win32-x64-msvc': 1.74.0
+      oxlint-tsgolint: 0.24.0
+      vite-plus: 0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
 
   p-filter@2.1.0:
     dependencies:
@@ -5442,7 +5661,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.22.5:
+  tsx@4.23.0:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -5454,7 +5673,7 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typebox@1.3.3: {}
+  typebox@1.3.4: {}
 
   typed-inject@5.0.0: {}
 
@@ -5509,33 +5728,33 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-plus@0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)):
+  vite-plus@0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)):
     dependencies:
       '@oxc-project/types': 0.138.0
       '@oxlint/plugins': 1.68.0
-      '@vitest/browser': 4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))(vitest@4.1.9)
-      '@vitest/browser-preview': 4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))(vitest@4.1.9)
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      '@voidzero-dev/vite-plus-core': 0.2.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)
-      oxfmt: 0.57.0(vite-plus@0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)))
-      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.3(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(tsx@4.22.5)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)))
+      '@vitest/browser': 4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))(vitest@4.1.10)
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      '@voidzero-dev/vite-plus-core': 0.2.4(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)
+      oxfmt: 0.57.0(vite-plus@0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)))
+      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(tsx@4.23.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)))
       oxlint-tsgolint: 0.24.0
-      vitest: 4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
     optionalDependencies:
-      '@voidzero-dev/vite-plus-darwin-arm64': 0.2.3
-      '@voidzero-dev/vite-plus-darwin-x64': 0.2.3
-      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.2.3
-      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.2.3
-      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.2.3
-      '@voidzero-dev/vite-plus-linux-x64-musl': 0.2.3
-      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.2.3
-      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.2.3
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.2.4
+      '@voidzero-dev/vite-plus-darwin-x64': 0.2.4
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.2.4
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.2.4
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.2.4
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.2.4
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.2.4
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.2.4
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@edge-runtime/vm'
@@ -5567,7 +5786,7 @@ snapshots:
       - vite
       - yaml
 
-  vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5):
+  vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -5578,17 +5797,17 @@ snapshots:
       '@types/node': 26.1.0
       esbuild: 0.28.1
       fsevents: 2.3.3
-      tsx: 4.22.5
+      tsx: 4.23.0
 
-  vitest@4.1.9(@types/node@26.1.0)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)):
+  vitest@4.1.10(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)):
     dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -5600,13 +5819,13 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5)
+      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.0
-      '@vitest/browser-preview': 4.1.9(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.5))(vitest@4.1.9)
-      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
-      '@vitest/ui': 4.1.9(vitest@4.1.9)
+      '@vitest/browser-preview': 4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0))(vitest@4.1.10)
+      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      '@vitest/ui': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,13 +8,14 @@ catalog:
   "@stryker-mutator/core": 9.6.1
   "@stryker-mutator/vitest-runner": 9.6.1
   "@types/node": 26.1.0
-  "@vitest/coverage-v8": 4.1.9
-  "@vitest/ui": 4.1.9
-  fallow: 3.3.0
-  tsx: 4.22.5
-  typebox: 1.3.3
-  vitest: 4.1.9
-  vite-plus: 0.2.3
+  "@vitest/coverage-v8": 4.1.10
+  "@vitest/ui": 4.1.10
+  fallow: 3.5.0
+  oxlint: 1.74.0
+  tsx: 4.23.0
+  typebox: 1.3.4
+  vitest: 4.1.10
+  vite-plus: 0.2.4
   typescript: 7.0.2
   zod: 4.4.3
 
@@ -39,6 +40,25 @@ blockExoticSubdeps: true
 minimumReleaseAge: 10080 # 1 week
 minimumReleaseAgeExclude:
   - "@fallow-cli/*"
+  - "@oxlint/binding-android-arm-eabi@1.74.0"
+  - "@oxlint/binding-android-arm64@1.74.0"
+  - "@oxlint/binding-darwin-arm64@1.74.0"
+  - "@oxlint/binding-darwin-x64@1.74.0"
+  - "@oxlint/binding-freebsd-x64@1.74.0"
+  - "@oxlint/binding-linux-arm-gnueabihf@1.74.0"
+  - "@oxlint/binding-linux-arm-musleabihf@1.74.0"
+  - "@oxlint/binding-linux-arm64-gnu@1.74.0"
+  - "@oxlint/binding-linux-arm64-musl@1.74.0"
+  - "@oxlint/binding-linux-ppc64-gnu@1.74.0"
+  - "@oxlint/binding-linux-riscv64-gnu@1.74.0"
+  - "@oxlint/binding-linux-riscv64-musl@1.74.0"
+  - "@oxlint/binding-linux-s390x-gnu@1.74.0"
+  - "@oxlint/binding-linux-x64-gnu@1.74.0"
+  - "@oxlint/binding-linux-x64-musl@1.74.0"
+  - "@oxlint/binding-openharmony-arm64@1.74.0"
+  - "@oxlint/binding-win32-arm64-msvc@1.74.0"
+  - "@oxlint/binding-win32-ia32-msvc@1.74.0"
+  - "@oxlint/binding-win32-x64-msvc@1.74.0"
   - "@types/node@25.9.2"
   - "@typescript/typescript-aix-ppc64@7.0.2"
   - "@typescript/typescript-darwin-arm64@7.0.2"
@@ -61,16 +81,17 @@ minimumReleaseAgeExclude:
   - "@typescript/typescript-win32-arm64@7.0.2"
   - "@typescript/typescript-win32-x64@7.0.2"
   - typescript@7.0.2
-  - "@voidzero-dev/vite-plus-core@0.2.3"
-  - "@voidzero-dev/vite-plus-darwin-arm64@0.2.3"
-  - "@voidzero-dev/vite-plus-darwin-x64@0.2.3"
-  - "@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.3"
-  - "@voidzero-dev/vite-plus-linux-arm64-musl@0.2.3"
-  - "@voidzero-dev/vite-plus-linux-x64-gnu@0.2.3"
-  - "@voidzero-dev/vite-plus-linux-x64-musl@0.2.3"
-  - "@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.3"
-  - "@voidzero-dev/vite-plus-win32-x64-msvc@0.2.3"
-  - vite-plus@0.2.3
+  - "@voidzero-dev/vite-plus-core@0.2.4"
+  - "@voidzero-dev/vite-plus-darwin-arm64@0.2.4"
+  - "@voidzero-dev/vite-plus-darwin-x64@0.2.4"
+  - "@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.4"
+  - "@voidzero-dev/vite-plus-linux-arm64-musl@0.2.4"
+  - "@voidzero-dev/vite-plus-linux-x64-gnu@0.2.4"
+  - "@voidzero-dev/vite-plus-linux-x64-musl@0.2.4"
+  - "@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.4"
+  - "@voidzero-dev/vite-plus-win32-x64-msvc@0.2.4"
+  - vite-plus@0.2.4
   - typebox@1.3.3
   - zod@4.4.3
   - fallow
+  - oxlint@1.74.0

--- a/skills/resultar/SKILL.md
+++ b/skills/resultar/SKILL.md
@@ -1,198 +1,189 @@
 ---
 name: resultar
-description: Use this skill whenever the user is writing, reviewing, migrating, or documenting TypeScript code that uses Resultar, Result<T, E>, ResultAsync<T, E>, createTaggedError, matchError, safeTry, or typed error handling. Trigger for questions about replacing thrown exceptions, modeling domain errors, composing sync/async fallible operations, using tagged errors with Result, improving Resultar API docs, or adding tests for Resultar-style flows, even if the user only says "result", "typed errors", "safe try", or "err/ok".
+description: Build, review, migrate, test, and document TypeScript code using Resultar v3.5+, including Result, ResultAsync, StrictResult, createTaggedError, safeTry, request adapters, and resultar-check. Use when expected failures should become typed values, thrown or rejected work must be wrapped, Resultar pipelines or async policies need design, HTTP JSON needs TypeBox or Zod validation, Resultar diagnostics need configuration, or an existing Resultar codebase needs review or migration.
 ---
 
-# Resultar
+# Resultar Engineering
 
-Resultar is an ESM-only TypeScript library for explicit error handling:
+Use Resultar to keep expected failures explicit in TypeScript without introducing an application
+runtime. Produce code that preserves concrete success and error types from the domain boundary to
+the final transport, job, CLI, or integration boundary.
 
-```ts
-Result<T, E>
-ResultAsync<T, E>
-StrictResult<T, E extends Error>
-StrictResultAsync<T, E extends Error>
-```
+## Start From Repository Truth
 
-Resultar began as an initial fork of `neverthrow`, but v2 should be treated as its own API direction:
-explicit wrappers, tagged errors, strict service-boundary aliases, and ESM-only packaging.
+1. Inspect the consuming project's `package.json`, lockfile, Resultar version, module format, and
+   TypeScript version before proposing code.
+2. Prefer the installed package types and local source over remembered APIs.
+3. In the Resultar repository, use these sources in order:
+   - `packages/resultar/src/index.ts` for public exports.
+   - `packages/resultar/README.md` and `DOCUMENTATION.md` for current semantics and examples.
+   - `packages/check/README.md` for diagnostics.
+   - `packages/request*/README.md` and `examples/request/` for request integrations.
+4. Adapt examples when the consumer uses an older Resultar version; do not silently emit v3.5 APIs
+   that are absent locally.
 
-Use this skill to produce Resultar-native code, examples, reviews, tests, and documentation. Favor the library's public API over ad hoc unions, thrown exceptions, or nullable returns.
+## Apply Opinionated Defaults
 
-## First Steps
-
-1. Check the user's installed or local Resultar version when the repository is available.
-2. Prefer local source and README over memory:
-   - `src/index.ts` for exported API
-   - `src/result.ts` for `Result`
-   - `src/result-async.ts` for `ResultAsync`
-   - `src/tagged-error.ts` for tagged errors
-   - `README.md` for current examples
-3. If the task is about a different project consuming Resultar, inspect its package version and import style before writing code.
-
-## Core Model
-
-- Use `Result<T, E>` for synchronous fallible work.
-- Use `ResultAsync<T, E>` for promise-based fallible work.
+- Return `Result<T, E>` for synchronous fallible work and `ResultAsync<T, E>` for asynchronous
+  fallible work.
 - Prefer `StrictResult<T, E extends Error>` and `StrictResultAsync<T, E extends Error>` at
-  application and backend service boundaries.
-- Use `ok(value)` and `err(error)` to construct plain results.
-- Use tagged errors when `E` should be a real typed `Error` subclass with stable metadata.
-- Prefer `createTaggedError` for expected domain/application failures. Keep strings, enums, and
-  lightweight objects for narrow local flows only.
-- Match plain results at boundaries with `result.match(okHandler, errHandler)`.
-- Match tagged-error results at boundaries with `result.matchTags(okHandler, handlers)`.
-- Do not throw for expected domain failures; return `Err`.
-- Do not return `T | Error` as the main model unless the user explicitly wants that style.
+  application, service, HTTP, job, queue, CLI, and integration boundaries.
+- Prefer `createTaggedError` for expected domain and application failures that need stable identity,
+  metadata, causes, serialization, or exhaustive handling.
+- Keep error unions specific. Let composition widen them naturally; do not collapse them to `Error`
+  before the boundary.
+- Return `Err` for expected failures. Reserve `throw` for programmer defects, invalid library
+  arguments, or deliberate terminal/process boundaries.
+- Wrap third-party throws and promise rejections at the edge, then keep the internal flow Resultar-
+  native.
+- Avoid `T | Error`, sentinel `null`, broad `try/catch`, rejected expected failures, and unsafe casts
+  as substitutes for a Resultar error channel.
+- Keep `_unsafeUnwrap()` and `_unsafeUnwrapErr()` in tests. Use `unwrapOrThrow()` only when throwing
+  is explicitly the intended boundary behavior.
 
-## Result Guidelines
+## Choose The Composition Operator
 
-For sync workflows:
+| Need                                      | Prefer                   |
+| ----------------------------------------- | ------------------------ |
+| Transform an `Ok` without failure         | `map`                    |
+| Transform an `Err`                        | `mapErr`                 |
+| Validate an `Ok` with a predicate         | `filterOrElse`           |
+| Continue with a sync fallible step        | `andThen`                |
+| Continue from `Result` into `ResultAsync` | `asyncAndThen`           |
+| Recover the whole error channel           | `orElse`                 |
+| Recover selected tagged errors            | `catchTag` / `catchTags` |
+| Branch directly                           | `isOk()` / `isErr()`     |
+| Convert a result at a boundary            | `match` / `matchTags`    |
+| Map selected tagged errors with fallback  | `matchTagsPartial`       |
+| Reuse a named Result combinator           | `pipe`                   |
+| Write a readable linear pipeline          | `safeTry` with `yield*`  |
 
-```ts
-import type { StrictResult } from 'resultar'
+Use `catchTags` for partial pipeline recovery; unhandled tags stay in the error channel. Do not
+invent `partialCatchTags`. Use `matchTagsPartial` only for boundary matching with a deliberate
+fallback.
 
-import { createTaggedError, ok } from 'resultar'
-
-class InvalidPortError extends createTaggedError({
-  name: 'InvalidPortError',
-  message: 'Invalid port $value',
-}) {}
-
-const parsePort = (value: string): StrictResult<number, InvalidPortError> => {
-  const port = Number(value)
-
-  return Number.isInteger(port) && port > 0 ? ok(port) : InvalidPortError.err({ value })
-}
-```
-
-Use:
-
-- `map(fn)` for infallible value transforms.
-- `mapErr(fn)` for error transforms.
-- `filterOrElse(predicate, onFalse)` for validating an `Ok` value without writing `andThen` boilerplate.
-- `andThen(fn)` for fallible sync composition.
-- `asyncAndThen(fn)` when a sync result needs to continue into `ResultAsync`.
-- `orElse(fn)` for recovery.
-- `catchTag(tag, fn)` for recovering one tagged error variant.
-- `catchTags(handlers)` for partial recovery of multiple tagged error variants; unhandled tags stay
-  in the `Err` side.
-- `match(okFn, errFn)` at external boundaries.
-- `isOk()` / `isErr()` for type narrowing.
-- `pipe(fn, ...)` for reusable Result combinators.
-
-## ResultAsync Guidelines
-
-Wrap promises with:
+## Model Tagged Errors
 
 ```ts
-fromPromise(promise, toError)
-fromSafePromise(promise)
-tryCatchAsync(promiseOrFactory, toError?)
-fromThrowableAsync(fn, toError?)
-```
-
-Use `ResultAsync` methods for composition instead of `await` plus manual branching unless the code is clearer at a boundary.
-
-```ts
-const user = fetchUser(id)
-  .andThen(validateUser)
-  .map((user) => user.email)
-  .mapErr((cause) => new Error('Could not load user email', { cause }))
-```
-
-`tryCatchAsync(() => promise)` catches both promise rejections and synchronous throws from the factory.
-
-## Tagged Error Guidelines
-
-Use `createTaggedError` when errors need a stable tag, typed metadata, JSON serialization, cause-chain lookup, or exhaustive matching.
-
-```ts
-import { createTaggedError } from 'resultar'
+import { createTaggedError, ok } from "resultar";
+import type { StrictResult } from "resultar";
 
 class InvalidEmailError extends createTaggedError({
-  name: 'InvalidEmailError',
-  message: 'Invalid email $email',
+  name: "InvalidEmailError",
+  message: "Invalid email $email",
 }) {}
+
+const validateEmail = (email: string): StrictResult<string, InvalidEmailError> =>
+  email.includes("@") ? ok(email) : InvalidEmailError.err({ email });
 ```
 
-Template variables like `$email` become required constructor props. A static `.err(props)` helper returns `Result<never, ErrorClass>`.
+- Let message-template variables define required constructor props.
+- Preserve `cause` when converting an external failure.
+- Treat `ErrorClass.is(value)` as nominal; do not rely on spoofed `_tag` objects.
+- Use `TaggedEnum` only for lightweight tagged domain variants that do not need to be real errors.
+- Include an `Error` handler when a matched union can contain untagged errors.
+
+## Compose Async Work
+
+Wrap uncontrolled async work with the helper that matches how it is created:
+
+- Use `fromPromise(promise, toError)` for an already-created promise.
+- Use `tryResultAsync({ try, catch })` or `tryResultAsync(factory, toError)` when creating the
+  promise can throw synchronously.
+- Use `fromSafePromise` only when rejection is impossible by contract.
+- Use `fromCallback` for callback or subscription APIs with explicit cleanup.
+- Use `runPromise` only at a terminal boundary that intentionally resolves or throws.
+
+Prefer lazy Resultar policies over ad hoc timers or `Promise.race`:
+
+- Use `ResultAsync.retry` / `retryOrElse` for typed retry and fallback policy.
+- Use `timeout`, `race`, `raceAll`, or `raceFirst` for signal-aware concurrency.
+- Use mapped `forEach` for first-error batch work and mapped `validateAll` for collecting every
+  independent validation error.
+- Use `withResource` when successful acquisition must always trigger best-effort release.
+- Pass the provided abort signal into the underlying client; cancellation is cooperative.
+
+Use `tap`, `tapError`, and `log` only for best-effort observation. Use `andThen`, `orElse`, or a
+Resultar wrapper when callback failure must change control flow.
+
+## Use `safeTry` For Linear Flows
 
 ```ts
-const validateEmail = (email: string) =>
-  email.includes('@') ? ok(email) : InvalidEmailError.err({ email })
-```
-
-Reserved template variables are rejected: `_tag`, `name`, `message`, `messageTemplate`,
-`fingerprint`, `stack`, and `cause`. Static `.is(value)` is nominal and requires an actual instance
-of the generated error class.
-
-At `Result` boundaries, use `result.matchTags(okHandler, handlers)` for exhaustive handling of
-tagged-error unions. Add an `Error` handler when plain or untagged `Error` is part of the union. Use
-standalone `matchError` when you only have an error value, and `matchErrorPartial` only when a
-fallback is intentional.
-
-Do not propose `partialCatchTags`: `catchTags` is already partial recovery. If the user needs partial
-boundary mapping, use `matchTagsPartial(okHandler, handlers, fallback)`.
-
-Use `TaggedEnum<Members>` for lightweight tagged domain unions that do not need to extend `Error`.
-Prefer `createTaggedError` when the value should be throwable, carry `cause`, serialize like an
-error, or compose through `matchError`.
-
-## safeTry Guidelines
-
-Use `safeTry` for linear workflows where nested `andThen` chains would be harder to read.
-
-```ts
-const createUser = (email: string) =>
-  safeTry(function* () {
-    const validEmail = yield* validateEmail(email)
-    const user = yield* insertUser(validEmail)
-
-    return ok(user)
-  })
-```
-
-For async generators, `yield*` works with both `Result` and `ResultAsync`.
-
-```ts
-const saveUser = (email: string) =>
+const createUser = (input: CreateUserInput): StrictResultAsync<User, CreateUserError> =>
   safeTry(async function* () {
-    const validEmail = yield* validateEmail(email)
-    const user = yield* insertUserAsync(validEmail)
+    const email = yield* validateEmail(input.email);
+    const available = yield* ensureEmailAvailable(email);
+    const user = yield* insertUser({ ...input, email: available });
 
-    return ok(user)
-  })
+    return ok(user);
+  });
 ```
 
-Prefer `yield* result` and `yield* resultAsync`. `Result.safeUnwrap()` exists for compatibility but is not usually needed.
+- Use `yield*` for both `Result` and `ResultAsync` values.
+- Wrap raw promises before yielding them.
+- Do not use raw `await` or broad `try/catch` inside a Resultar `safeTry` workflow.
+- Prefer `yield* result` over legacy `safeUnwrap()`.
 
-## Observation And Cleanup
+## Keep Boundaries Concrete
 
-Use side-effect methods only for observation and cleanup:
+- Define request, command, and event payloads with concrete types; do not widen them to generic JSON
+  records before the use case.
+- Keep transport concerns out of domain code. Convert tagged errors to HTTP responses, CLI exit
+  codes, job outcomes, or logs at the outer boundary.
+- Use exhaustive `matchTags` when every tagged error needs a distinct mapping.
+- Use local `catchTag` / `catchTags` only when recovery belongs to domain policy.
 
-- `tap(fn)` runs only for `Ok` and preserves the result.
-- `tapError(fn)` runs only for `Err` and preserves the result.
-- `log(fn)` runs for both states as `(value, error)` and preserves the result.
-- `toDisposable(fn)` and `toAsyncDisposable(fn)` create Node.js 24 disposable wrappers for `using`
-  and `await using`.
+## Handle HTTP JSON Requests
 
-Callback errors are intentionally ignored, including disposable cleanup callbacks. If callback failure
-should affect control flow, use `andThen`, `orElse`, or `tryCatch`.
+Use the Resultar request family instead of repeating fetch, parsing, validation, retry, and error
+mapping logic:
 
-## Testing Guidance
+- Use `resultar-request` with `validator` or `decode` for schema-library-agnostic boundaries.
+- Use `resultar-request-typebox` when contracts use TypeBox and preserve `Static<typeof schema>`.
+- Use `resultar-request-zod` when contracts use Zod and preserve transformed
+  `z.output<typeof schema>`.
+- Map request, HTTP, invalid-JSON, and validation failures to concrete tagged errors when they cross
+  an application boundary.
 
-Use `vite-plus/test` in this repository.
+Read `references/integrations.md` before implementing request adapters or diagnostics.
 
-- Use runtime assertions for `Ok`/`Err` behavior.
-- Use `expectTypeOf` for type narrowing and inferred tagged-error props.
-- Use `// @ts-expect-error` for intentional compile-time failures.
-- Prefer checking public behavior over private internals.
+## Validate In The Preferred Order
 
-## References
+1. Run the `resultar-check` CLI as the authoritative project and CI gate. It runs TypeScript and the
+   full Resultar rule set against the project.
+2. Configure the `resultar-check` TypeScript language-service plugin for editor diagnostics using
+   the workspace TypeScript version.
+3. Add Oxlint, ESLint, or Deno Lint adapters only as optional AST-only feedback. Do not present them
+   as replacements for the CLI or language-service plugin.
+4. Run the repository's native formatting, build, tests, analysis, package smoke, and example
+   workflows when available.
 
-Read these only when needed:
+Treat stable `resultar/*` rule IDs as architecture feedback. Fix the typed boundary or composition
+problem instead of suppressing diagnostics broadly. Use narrow ignore patterns only for deliberate
+test, script, generated, or process-boundary exceptions.
 
-- `references/api.md` for API details and method semantics.
-- `references/patterns.md` for copyable recipes.
-- `references/review-checklist.md` for code review and migration checks.
+## Test And Document Behavior
+
+- Cover `Ok` and every expected `Err` path with runtime tests.
+- Cover inferred error unions, tagged-error props, narrowing, and exhaustive handlers with type
+  tests. Use `expectTypeOf` and `@ts-expect-error` where supported.
+- Use the consuming project's test runner. Use `vite-plus/test` inside this repository.
+- Test retry, timeout, cancellation, concurrency, and cleanup policies with deterministic fakes.
+- Derive documentation examples from checked source or runnable examples and keep package links
+  reciprocal when packages are alternatives or adapters.
+
+## Review Before Finishing
+
+- Run the project's Resultar CLI check after edits.
+- Confirm no Result or ResultAsync value is silently discarded.
+- Confirm mapped errors preserve `cause` and useful metadata.
+- Confirm boundary handlers cover the actual error union.
+- Confirm request validation derives the downstream type instead of widening it.
+- Confirm validation claims match commands that actually passed.
+
+## Load References Selectively
+
+- Read `references/api.md` for current v3.5 exports, collection helpers, and async policy semantics.
+- Read `references/patterns.md` for copyable implementation and migration patterns.
+- Read `references/integrations.md` for request adapters and the CLI/editor/lint workflow.
+- Read `references/review-checklist.md` for reviews, migrations, and final validation.

--- a/skills/resultar/agents/openai.yaml
+++ b/skills/resultar/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Resultar Engineering"
+  short_description: "Build and review typed Resultar workflows"
+  default_prompt: "Use $resultar to build or review a typed Resultar workflow."

--- a/skills/resultar/evals/evals.json
+++ b/skills/resultar/evals/evals.json
@@ -3,20 +3,38 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "In a TypeScript service using Resultar, refactor this createUser flow so expected failures are typed instead of thrown. It validates email, checks if the user exists, inserts into a repository, and the route needs HTTP responses for invalid email, duplicate user, and database failure. Show the Resultar code with tagged errors and boundary matching.",
-      "expected_output": "Uses Result<ResultAsync as appropriate), createTaggedError classes with inferred props, .err helpers, and matchError at the HTTP boundary. Avoids T | Error as the primary model and avoids throwing for expected domain failures.",
+      "prompt": "Refactor a TypeScript createUser service that currently throws for invalid email, duplicate users, and repository failures. Use the Resultar version installed in the repository, preserve concrete error metadata and causes, and show how an HTTP route converts the final workflow into responses.",
+      "expected_output": "Inspects local Resultar truth; models expected failures with createTaggedError and StrictResult/StrictResultAsync; composes narrow errors with map, andThen, or asyncAndThen; and uses exhaustive matchTags at the HTTP boundary without T | Error, broad catches, or production unsafe unwraps.",
       "files": []
     },
     {
       "id": 2,
-      "prompt": "I have a Resultar async pipeline that calls an external API and then saves the response. Please write an example using ResultAsync, fromPromise or tryCatchAsync, and add metrics/logging without changing the result. Explain when to use tap, tapError, log, and toAsyncDisposable.",
-      "expected_output": "Shows ResultAsync composition, wraps external promises, uses side-effect helpers only for observation/cleanup, states that callback failures are ignored, and uses map/andThen/orElse for transformations.",
+      "prompt": "Design a Resultar async workflow that loads a user from a flaky upstream, retries only retryable failures, applies one overall timeout, races a primary and replica for the first success, writes the result with bounded concurrency, always releases an acquired session, and records metrics. Explain cancellation and cleanup semantics.",
+      "expected_output": "Uses ResultAsync.retry or retryOrElse, timeout nesting that makes the total budget explicit, raceFirst for first success, bounded forEach, withResource, and tap/tapError for best-effort observation. It forwards AbortSignal to underlying work and states that release/observation failures are best-effort unless modeled in the result channel.",
       "files": []
     },
     {
       "id": 3,
-      "prompt": "Write Vite+ tests for a Resultar tagged error API. I need runtime tests for .err(), .is(), matchError exhaustiveness behavior, and type-level tests for required template props using expectTypeOf and @ts-expect-error.",
-      "expected_output": "Uses vite-plus/test, node:assert runtime checks, expectTypeOf for inferred types, and @ts-expect-error for invalid constructor/err props. Covers .err() returning Result<never, ErrorClass>.",
+      "prompt": "Add tests for a Resultar tagged-error workflow. Cover success and every expected failure at runtime, inferred template props and error unions at the type level, exhaustive boundary matching, and deterministic retry, timeout, cancellation, and cleanup behavior. Use this repository's real test runner.",
+      "expected_output": "Uses vite-plus/test in the Resultar repository, runtime assertions for Ok and Err paths, expectTypeOf and @ts-expect-error for type behavior, and deterministic fakes for async policy. It keeps _unsafeUnwrap helpers in tests only and validates exhaustive tagged-error handling.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Implement a typed HTTP JSON request for a User response and show both alternatives: one service uses TypeBox and another uses a transforming Zod schema. Map request, status-specific HTTP, invalid JSON, and validation failures into tagged application errors, and retry transient failures safely.",
+      "expected_output": "Chooses resultar-request-typebox with Static<typeof schema> and resultar-request-zod with z.output<typeof schema>; uses a request factory for retry; preserves Zod transforms; maps all request failure categories with causes and metadata; and explains that the shared resultar-request core owns transport, parsing, retry, and error mapping.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Set up Resultar validation for a TypeScript 7 project used by humans and coding agents. I need the correct project/CI command, editor diagnostics, and optional Oxlint, ESLint, or Deno Lint integration. Explain the order and what each surface can prove.",
+      "expected_output": "Makes the resultar-check CLI the authoritative first gate, configures the TypeScript language-service plugin with workspace TypeScript second, and places Oxlint/ESLint/Deno Lint third as optional AST-only feedback. It uses stable resultar/* rules, does not claim lint replaces type-aware checks, and recommends native tests/build/examples afterward.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Review a Resultar pull request that adds domain workflows, request examples, and README guidance. Find stale or unsafe guidance such as thrown expected errors, discarded Results, map returning Result, broad JSON response types, incorrect request-adapter types, hand-written async policies, and lint-only validation claims. Propose focused fixes and a verification plan without touching unrelated changes.",
+      "expected_output": "Checks installed package/source truth, reports concrete review findings, recommends tagged explicit errors and correct combinators, preserves TypeBox Static and Zod z.output types, prefers built-in async policies, requires CLI then language-server then optional lint validation, includes runtime/type/example checks, and preserves unrelated workspace edits.",
       "files": []
     }
   ]

--- a/skills/resultar/references/api.md
+++ b/skills/resultar/references/api.md
@@ -1,287 +1,217 @@
-# Resultar API Reference For AI Agents
+# Resultar v3.5+ API Guide
 
-Use this reference when writing or reviewing code that consumes Resultar.
+Use this reference after checking the version installed by the consuming project. The local package
+types and source are authoritative when they differ from this guide.
 
-Resultar began as an initial fork of `neverthrow`, but v2 should be documented and consumed as a
-Resultar-specific API with tagged errors, strict service-boundary aliases, and ESM-only packaging.
+## Contents
 
-## Package Shape
+- [Package Baseline](#package-baseline)
+- [Core Types And Constructors](#core-types-and-constructors)
+- [Composition And Recovery](#composition-and-recovery)
+- [Tagged Errors](#tagged-errors)
+- [Boundary Matching](#boundary-matching)
+- [Async Boundaries](#async-boundaries)
+- [Async Policies](#async-policies)
+- [Collections And Control Flow](#collections-and-control-flow)
+- [`safeTry`](#safetry)
+- [Observation And Cleanup](#observation-and-cleanup)
 
-Resultar is ESM-only and targets Node.js 24+.
+## Package Baseline
 
-```ts
-import {
-  Result,
-  ResultAsync,
-  createTaggedError,
-  err,
-  errAsync,
-  findCause,
-  fromPromise,
-  fromSafePromise,
-  fromThrowable,
-  fromThrowableAsync,
-  isError,
-  matchError,
-  matchErrorPartial,
-  ok,
-  okAsync,
-  safeTry,
-  tryCatch,
-  tryCatchAsync,
-  unit,
-  unitAsync,
-} from 'resultar'
-```
+Resultar v3.5 is an ESM package targeting Node.js 24+. The repository currently uses TypeScript 7.
+Do not infer consumer requirements from memory: inspect `package.json`, the lockfile, and exported
+types first.
 
-Use type-only imports for exported types:
+Prefer named imports and type-only imports:
 
 ```ts
-import type {
-  StrictResult,
-  StrictResultAsync,
-  TaggedEnum,
-  TaggedErrorClass,
-  TaggedErrorInstance,
-  TaggedErrorOptions,
-} from 'resultar'
+import { ResultAsync, createTaggedError, ok, safeTry, tryResult, tryResultAsync } from "resultar";
+import type { StrictResult, StrictResultAsync } from "resultar";
 ```
 
-## Result<T, E>
+`tryCatch` and `tryCatchAsync` remain compatibility aliases. Prefer `tryResult` and
+`tryResultAsync` in new v3.5+ code.
 
-`Result<T, E>` is the sync fallible value type.
-It remains generic for local flows, but production-facing expected failures should usually be real
-`Error` instances through `StrictResult` and `createTaggedError`.
+## Core Types And Constructors
 
-Constructors:
+| Need                                                | API                                      |
+| --------------------------------------------------- | ---------------------------------------- |
+| Synchronous fallible value                          | `Result<T, E>`                           |
+| Asynchronous fallible value                         | `ResultAsync<T, E>`                      |
+| Error-only sync channel                             | `StrictResult<T, E extends Error>`       |
+| Error-only async channel                            | `StrictResultAsync<T, E extends Error>`  |
+| Successful value                                    | `ok(value)` / `okAsync(value)`           |
+| Successful `undefined`                              | `unit()` / `unitAsync()`                 |
+| Expected failure                                    | `err(error)` / `errAsync(error)`         |
+| Catch synchronous throws now                        | `tryResult(fn, toError)`                 |
+| Wrap a synchronous throwing function                | `fromThrowable(fn, toError)`             |
+| Catch promise rejection or a throwing async factory | `tryResultAsync(input, toError)`         |
+| Wrap an async throwing function                     | `fromThrowableAsync(fn, toError)`        |
+| Deliberately leave Resultar at a terminal boundary  | `runSync(result)` / `runPromise(result)` |
 
-- `ok(value)` -> `Result<T, never>`
-- `err(error)` -> `Result<never, E>`
-- `unit()` -> `Result<undefined, never>`
-- `tryCatch(fn, errorFn?)` -> catches synchronous throws
-- `fromThrowable(fn, errorFn?)` -> wraps a throwing function
-
-Methods:
-
-- `isOk()` narrows to `Result<T, never>`.
-- `isErr()` narrows to `Result<never, E>`.
-- `map(fn)` transforms only the `Ok` value.
-- `mapErr(fn)` transforms only the `Err` value.
-- `filterOrElse(predicate, onFalse)` keeps `Ok` values that pass and converts failures to `Err`.
-- `andThen(fn)` chains a function returning `Result`.
-- `asyncAndThen(fn)` chains a function returning `ResultAsync`.
-- `orElse(fn)` recovers from an error with another `Result`.
-- `catchTag(tag, fn)` recovers from one tagged error variant.
-- `catchTags(handlers)` partially recovers from multiple tagged error variants; unhandled tags stay
-  in the `Err` side.
-- `match(okFn, errFn)` returns the output of the matching handler.
-- `matchTags(okFn, handlers)` matches `Ok` and tagged `Error` variants without nesting `matchError`.
-- `matchTagsPartial(okFn, handlers, fallback)` matches selected tagged `Error` variants and sends
-  unhandled errors to `fallback`.
-- `pipe(fn, ...)` applies reusable combinators to the current `Result`.
-- `unwrapOr(defaultValue)` returns the value or default.
-- `unwrapOrThrow()` returns the value or throws the error.
-- `_unsafeUnwrap()` and `_unsafeUnwrapErr()` are for tests.
-- `safeUnwrap()` is legacy support for `safeTry`; prefer `yield* result`.
-
-Static methods:
-
-- `Result.ok(value)`
-- `Result.err(error)`
-- `Result.unit()`
-- `Result.tryCatch(fn, errorFn?)`
-- `Result.fromThrowable(fn, errorFn?)`
-- `Result.combine(results)` short-circuits at the first error.
-- `Result.combineWithAllErrors(results)` collects all errors.
-
-## StrictResult<T, E extends Error>
-
-`StrictResult<T, E extends Error>` is a type-only alias for `Result<T, E>` when the error channel
-must contain real `Error` instances.
-
-Use it at backend/application/service boundaries:
+Use the named options form when it improves readability:
 
 ```ts
-class InvalidEmailError extends createTaggedError({
-  name: 'InvalidEmailError',
-  message: 'Invalid email $email',
-}) {}
-
-const validateEmail = (email: string): StrictResult<string, InvalidEmailError> =>
-  email.includes('@') ? ok(email) : InvalidEmailError.err({ email })
+const parsed = tryResult({
+  try: () => JSON.parse(input) as unknown,
+  catch: (cause) => new ParsePayloadError({ cause }),
+});
 ```
 
-Keep `Result<T, E>` for narrow local flows that intentionally use strings, enums, or lightweight
-domain objects. Prefer `StrictResult` when logging, `cause`, stack traces, and tagged-error matching
-matter.
+`runSync` returns the `Ok` value or throws the `Err`; `runPromise` resolves the `Ok` value or
+rejects with the `Err`. Keep both at framework, bootstrap, CLI, or test boundaries.
 
-Expected domain/application failures should normally be Resultar tagged errors. Untagged `Error`
-subclasses are still appropriate for external/native/library failures that already carry useful
-identity, such as validation, database, abort, or platform errors.
+## Composition And Recovery
 
-## API Decision Guide
+- `map` transforms an `Ok` value with an infallible function.
+- `mapErr` transforms an `Err` value.
+- `filterOrElse` validates or narrows an `Ok` value and introduces a typed error on failure.
+- `andThen` chains fallible work. On `ResultAsync`, it accepts sync or async Resultar work.
+- `asyncAndThen` bridges a synchronous `Result` into `ResultAsync`.
+- `orElse` recovers the complete error channel.
+- `catchTag` recovers one tagged error.
+- `catchTags` recovers selected tagged errors; unhandled variants stay in the error union.
+- `pipe` applies named combinators without changing Result semantics.
 
-- Use `map` when an `Ok` value changes and the transform cannot fail.
-- Use `andThen` when the next step can fail and returns `Result`.
-- Use `asyncAndThen` when a sync `Result` continues into `ResultAsync`.
-- Use `mapErr` when an error should be transformed.
-- Use `orElse` when an error should recover into another result.
-- Use `catchTag` / `catchTags` for local tagged-error recovery.
-- Use `match` for simple boundaries.
-- Use `matchTags` when every tagged error must be mapped.
-- Use `matchTagsPartial` when selected tagged errors need custom handling and the rest should go to a
-  fallback.
-- Use `fromPromise(promise, toError)` when the promise already exists.
-- Use `tryCatchAsync(() => promiseFactory(), toError?)` when creating the promise can throw
-  synchronously.
+Let each step expose its narrow error type and let composition infer the union:
 
-## ResultAsync<T, E>
+```ts
+type CreateUserError = InvalidEmailError | UserExistsError | SaveUserError;
 
-`ResultAsync<T, E>` wraps `Promise<Result<T, E>>` and is thenable.
+const createUser = (input: CreateUserInput): StrictResultAsync<User, CreateUserError> =>
+  validateEmail(input.email)
+    .asyncAndThen(ensureEmailAvailable)
+    .andThen((email) => saveUser({ ...input, email }));
+```
 
-Constructors:
-
-- `okAsync(value)` -> successful async result
-- `errAsync(error)` -> failed async result
-- `unitAsync()` -> successful async result with `undefined`
-- `fromPromise(promise, errorFn)` -> maps rejections into `Err`
-- `fromSafePromise(promise)` -> wraps a promise expected not to reject
-- `tryCatchAsync(promiseOrFactory, errorFn?)` -> catches rejections and sync throws from factories
-- `fromThrowableAsync(fn, errorFn?)` -> wraps an async throwing function
-
-Methods mirror `Result` where useful:
-
-- `map(fn)`
-- `mapErr(fn)`
-- `andThen(fn)` accepts functions returning `Result` or `ResultAsync`.
-- `orElse(fn)` accepts recovery functions returning `Result` or `ResultAsync`.
-- `match(okFn, errFn)` resolves to the handler output.
-- `matchTags(okFn, handlers)` resolves to direct tagged-error boundary handling.
-- `matchTagsPartial(okFn, handlers, fallback)` resolves to selected tagged-error boundary handling
-  with a fallback for unhandled errors.
-- `unwrapOr(defaultValue)` resolves to value or default.
-- `unwrapOrThrow()` resolves to value or throws the error.
-- Prefer `yield* resultAsync`; async `safeUnwrap()` is not part of the v2 API.
-
-Static methods:
-
-- `ResultAsync.combine(results)` short-circuits at the first error after all promises settle.
-- `ResultAsync.combineWithAllErrors(results)` collects all errors after all promises settle.
-
-`StrictResultAsync<T, E extends Error>` is the async type-only alias for Error-only failure channels.
+Do not manually cast the final error union. A surprising inferred union is usually evidence that a
+step has a broad or inaccurate signature.
 
 ## Tagged Errors
 
-`createTaggedError` creates a real `Error` subclass with stable metadata.
+`createTaggedError` creates nominal `Error` subclasses with stable `_tag`, message-template props,
+`cause`, `fingerprint`, `toJSON()`, and `.err()` support.
 
 ```ts
-class PaymentDeclinedError extends createTaggedError({
-  name: 'PaymentDeclinedError',
-  message: 'Payment $paymentId was declined by $provider',
+class UserNotFoundError extends createTaggedError({
+  name: "UserNotFoundError",
+  message: "User $userId was not found in $source",
 }) {}
+
+const missing = UserNotFoundError.err({ userId, source: "database" });
 ```
 
-Instances expose:
+- Let `$variables` in the message template define required constructor props.
+- Preserve the original failure with `cause` when adapting external code.
+- Keep the configured `name` equal to the class name.
+- Do not override the generated constructor.
+- Treat `ErrorClass.is(value)` as a nominal `instanceof`-based guard; a matching `_tag` is not
+  sufficient.
+- Avoid reserved template fields such as `_tag`, `name`, `message`, `messageTemplate`,
+  `fingerprint`, `stack`, and `cause`.
+- Use `TaggedEnum`/`taggedEnum` for lightweight tagged data that should not be an `Error`.
+- Use `redact`, `isRedacted`, and `revealRedacted` when sensitive error metadata must not serialize
+  or log by default.
+- Use `findCause` or an instance's `findCause` to inspect a typed cause chain.
 
-- `_tag`
-- `message`
-- `messageTemplate`
-- `fingerprint`
-- typed props inferred from `$variables`
-- `cause`
-- `toJSON()`
-- `findCause(ErrorClass)`
+## Boundary Matching
 
-Static members:
+Use branch methods inside an algorithm and matching when converting the completed result:
 
-- `ErrorClass.tag`
-- `ErrorClass.is(value)`, a nominal `instanceof`-based guard
-- `ErrorClass.err(props)`
+- `isOk()` / `isErr()` narrow for direct control flow.
+- `match(onOk, onErr)` handles a simple boundary.
+- `matchTags(onOk, handlers)` exhaustively maps tagged errors.
+- `matchTagsPartial(onOk, handlers, fallback)` handles selected tags with a deliberate fallback.
+- `matchError(error, handlers)` handles an error value directly.
+- `matchErrorPartial(error, handlers, fallback)` partially handles an error value.
 
-Reserved template variables are rejected because they conflict with `Error` or tagged-error
-metadata: `_tag`, `name`, `message`, `messageTemplate`, `fingerprint`, `stack`, and `cause`.
+Include an `Error` handler whenever an error union can contain an untagged `Error`. Do not invent
+`partialCatchTags`; `catchTags` already supports partial recovery.
 
-Use `.err(props)` when returning the error side of a result:
+## Async Boundaries
+
+Choose the wrapper based on ownership of the promise:
+
+- `fromPromise(existingPromise, toError)` wraps a promise that has already been created.
+- `tryResultAsync(() => createPromise(), toError)` also catches synchronous factory throws and is
+  preferred when the agent controls creation.
+- `fromSafePromise(promise)` is only for promises guaranteed not to reject by contract.
+- `fromCallback(options)` adapts callback or subscription APIs and returns
+  `ResultAsync<T, E | AbortError>`. Supply cleanup and forward cancellation where supported.
+- `AbortError` and `isAbortError` identify Resultar cancellation.
+
+Always map `unknown` causes into a specific error near the external boundary:
 
 ```ts
-const decline = (paymentId: string) => PaymentDeclinedError.err({ paymentId, provider: 'stripe' })
+const loadUser = (id: string): StrictResultAsync<User, LoadUserError> =>
+  tryResultAsync(
+    () => client.loadUser(id),
+    (cause) => new LoadUserError({ cause, id }),
+  );
 ```
 
-Use `TaggedEnum<Members>` for lightweight non-Error variants:
+## Async Policies
+
+Use the built-in lazy policies instead of hand-written `Promise.race`, timers, or retry loops:
+
+- `ResultAsync.retry(task, options)` retries typed failures and includes `AbortError` in the error
+  channel. Use `times`, `delayMs`, `jittered`, `while`, and the provided signal deliberately.
+- `ResultAsync.retryOrElse(task, options)` applies a typed fallback after retry exhaustion. The
+  exhausted task error is replaced by the fallback error channel.
+- `ResultAsync.timeout(task, options)` returns the task error or the typed `onTimeout` error.
+- `ResultAsync.race(left, right)` and `raceAll(tasks)` return the first settled result.
+- `ResultAsync.raceFirst(left, right)` returns the first `Ok`; if both fail, it returns the last
+  observed `Err`.
+- `ResultAsync.raceWith(left, right, handlers)` exposes the winner and a handle to the still-running
+  task for custom cooperative policy.
+- `ResultAsync.withResource({ acquire, use, release })` releases after every acquire-success path.
+  Release errors are best-effort and do not enter the result channel; model cleanup in `use` when it
+  must affect control flow.
+
+Race, timeout, retry, callback, and resource helpers rely on cooperative cancellation. Pass their
+`AbortSignal` into fetch, database, SDK, timer, or subscription work; aborting a wrapper cannot stop
+an underlying operation that ignores the signal.
+
+## Collections And Control Flow
+
+Both `Result` and `ResultAsync` provide collection helpers:
+
+- `combine` preserves array/tuple/record shape and returns the first error.
+- `combineWithAllErrors` collects every error.
+- `validateAll` collects all validation errors; async mapped use supports bounded `concurrency`.
+- `zip` combines exactly two values.
+- `firstSuccessOf` tries candidates until one succeeds and otherwise returns the final error.
+- `forEach` stops at the first error; use `{ discard: true }` when successful values are irrelevant.
+- `when`, `unless`, `loop`, and `iterate` model Resultar-native control flow where they improve
+  clarity.
+
+Prefer `ResultAsync.forEach(items, mapper, { concurrency })` for bounded first-error processing and
+`ResultAsync.validateAll(items, mapper, { concurrency })` for independent validation where every
+error matters.
+
+## `safeTry`
+
+Use `safeTry` when a linear generator is clearer than a chain:
 
 ```ts
-type PaymentError = TaggedEnum<{
-  CardDeclined: { readonly code: string }
-  InsufficientFunds: { readonly balance: number }
-}>
+const workflow = safeTry(async function* () {
+  const input = yield* validateInput(raw);
+  const remote = yield* loadRemote(input);
+  const saved = yield* saveRemote(remote);
+
+  return ok(saved);
+});
 ```
 
-## Matching Tagged Errors
-
-Use `matchError(error, handlers)` when all tagged errors in a union must be handled.
-
-```ts
-const response = matchError(error, {
-  InvalidEmailError: (error) => ({ statusCode: 400, body: error.toJSON() }),
-  UserAlreadyExistsError: (error) => ({ statusCode: 409, body: error.toJSON() }),
-  DatabaseError: (error) => ({ statusCode: 500, body: error.toJSON() }),
-})
-```
-
-When plain or untagged `Error` is part of the union, include an `Error` handler:
-
-```ts
-const message = matchError(error, {
-  DatabaseError: (error) => error.message,
-  Error: (error) => error.message,
-  InvalidEmailError: (error) => error.message,
-})
-```
-
-Use `matchErrorPartial(error, handlers, fallback)` when only selected errors need custom handling.
-
-Do not add `partialCatchTags`; `catchTags` already has partial recovery semantics. Use
-`matchTagsPartial(okHandler, handlers, fallback)` for partial boundary mapping.
+Use `yield*` for `Result` and `ResultAsync`. Wrap raw promises before yielding. Avoid raw `await`,
+`try/catch`, and legacy `safeUnwrap()` inside the generator.
 
 ## Observation And Cleanup
 
-`tap`, `tapError`, and `log` are best-effort observation helpers, not transform helpers.
+`tap`, `tapError`, and `log` preserve the original result. Callback throws and rejected callback
+promises are intentionally ignored, so use them only for best-effort logging, metrics, tracing, and
+observation. Use `andThen`, `orElse`, or a Resultar boundary when side-effect failure must alter the
+workflow.
 
-- They preserve the original `Result` or `ResultAsync`.
-- Callback errors are intentionally ignored, including disposable cleanup callbacks.
-- On `ResultAsync`, rejected callback promises are intentionally ignored.
-- Use them for metrics, logging, tracing, and cleanup.
-- Use `toDisposable` and `toAsyncDisposable` for Node.js 24 `using` / `await using` cleanup scopes.
-- Use `map`, `mapErr`, `andThen`, `orElse`, or `tryCatch` for fallible work that should affect the result.
-
-## Current Preferred Style
-
-Prefer this:
-
-```ts
-const result = validateInput(input)
-  .andThen(saveInput)
-  .tap((saved) => logger.info({ id: saved.id }, 'saved input'))
-  .tapError((error) => logger.error({ error }, 'failed to save input'))
-```
-
-Avoid this for expected failures:
-
-```ts
-try {
-  return await saveInputOrThrow(input)
-} catch (error) {
-  return error
-}
-```
-
-## Coming From Other Styles
-
-- From `try/catch`: convert uncontrolled throws at the edge with `tryCatch` / `tryCatchAsync`, then
-  return `Result` values from domain code.
-- From neverthrow-style wrappers: keep wrapper composition, but prefer tagged `Error` values for
-  production failure channels.
-- From raw `T | Error`: Resultar keeps `Ok` and `Err` structurally separate, so success values can be
-  `Error` objects without being mistaken for failures.
-- From application runtimes: Resultar does not provide dependency injection, fibers, schedules,
-  streams, scopes, or a runtime. Keep examples focused on explicit result composition.
+`toDisposable` and `toAsyncDisposable` integrate with Node.js `using` / `await using`; their
+cleanup callbacks are also best-effort. Prefer `withResource` for acquire/use/release workflows.

--- a/skills/resultar/references/integrations.md
+++ b/skills/resultar/references/integrations.md
@@ -1,0 +1,288 @@
+# Resultar Requests And Validation Tooling
+
+Use this reference for HTTP JSON integrations and Resultar-specific diagnostics. Verify package
+versions and local README files before copying an example.
+
+## Contents
+
+- [Choose A Request Package](#choose-a-request-package)
+- [Use The Schema-Agnostic Core](#use-the-schema-agnostic-core)
+- [Use The TypeBox Adapter](#use-the-typebox-adapter)
+- [Use The Zod Adapter](#use-the-zod-adapter)
+- [Map Request Errors](#map-request-errors)
+- [Apply Retry Correctly](#apply-retry-correctly)
+- [Validate In The Preferred Order](#validate-in-the-preferred-order)
+- [Configure The CLI And Language Server](#configure-the-cli-and-language-server)
+- [Use Lint Adapters As Secondary Feedback](#use-lint-adapters-as-secondary-feedback)
+- [Discover Repository Commands](#discover-repository-commands)
+
+## Choose A Request Package
+
+| Contract style                   | Package                    | Success type                 |
+| -------------------------------- | -------------------------- | ---------------------------- |
+| Custom type guard or decoder     | `resultar-request`         | Type guard or decoder output |
+| TypeBox schema                   | `resultar-request-typebox` | `Static<typeof schema>`      |
+| Zod schema, including transforms | `resultar-request-zod`     | `z.output<typeof schema>`    |
+
+All three share the same transport implementation. The adapters add schema validation and re-export
+the public `resultar-request` types. Install only the core and schema adapter the service needs.
+
+Keep request payloads concrete. Do not widen a known response contract to `JsonRecord`,
+`Record<string, unknown>`, or `unknown` after validation.
+
+## Use The Schema-Agnostic Core
+
+Use a type guard when validation does not transform the payload:
+
+```ts
+import { requestJson } from "resultar-request";
+
+type User = { readonly email: string; readonly id: string };
+
+const isUser = (value: unknown): value is User =>
+  typeof value === "object" &&
+  value !== null &&
+  "email" in value &&
+  typeof value.email === "string" &&
+  "id" in value &&
+  typeof value.id === "string";
+
+const user = requestJson({
+  request: () => fetch(`https://example.com/users/${userId}`),
+  validator: isUser,
+});
+```
+
+Use `decode` when validation also normalizes or transforms the response. The decoder must make
+success and validation failure explicit; check the installed package types for the exact shape.
+
+## Use The TypeBox Adapter
+
+```ts
+import { createTaggedError } from "resultar";
+import {
+  requestJson as requestJsonTypeBox,
+  type RequestJsonMapError,
+} from "resultar-request-typebox";
+import { Type, type Static } from "typebox";
+
+const userSchema = Type.Object(
+  {
+    email: Type.String(),
+    id: Type.String(),
+    plan: Type.Union([Type.Literal("free"), Type.Literal("team")]),
+  },
+  { additionalProperties: false },
+);
+
+type User = Static<typeof userSchema>;
+
+class UserApiError extends createTaggedError({
+  name: "UserApiError",
+  message: "User API $reason: $detail",
+}) {}
+
+const mapUserError = {
+  404: ({ statusCode }) => new UserApiError({ detail: `HTTP ${statusCode}`, reason: "not-found" }),
+  http: ({ statusCode }) => new UserApiError({ detail: `HTTP ${statusCode}`, reason: "http" }),
+  invalidJson: ({ cause }) =>
+    new UserApiError({ cause, detail: cause.message, reason: "invalid-json" }),
+  request: ({ cause }) => new UserApiError({ cause, detail: cause.message, reason: "request" }),
+  validation: ({ errors }) =>
+    new UserApiError({
+      detail: `${errors.length} validation issue(s)`,
+      reason: "validation",
+    }),
+} satisfies RequestJsonMapError;
+
+const user = requestJsonTypeBox({
+  request: () => fetch(`https://example.com/users/${userId}`),
+  schema: userSchema,
+  mapError: mapUserError,
+  retry: {
+    times: 2,
+    delayMs: ({ nextAttempt }) => nextAttempt * 100,
+    jittered: 0.2,
+  },
+});
+```
+
+The success channel is `User`, derived from `Static<typeof userSchema>`. Keep the named adapter
+alias when a file uses more than one request helper or when the schema library should be obvious at
+the call site.
+
+## Use The Zod Adapter
+
+```ts
+import { createTaggedError } from "resultar";
+import { requestJson as requestJsonZod, type RequestJsonMapError } from "resultar-request-zod";
+import { z } from "zod";
+
+const userSchema = z
+  .object({
+    email: z.string().email(),
+    id: z.string(),
+    seats: z.number().int().nonnegative(),
+  })
+  .transform((user) => ({
+    ...user,
+    email: user.email.toLowerCase(),
+    seatLabel: `${user.seats} seats`,
+  }));
+
+type User = z.output<typeof userSchema>;
+
+class UserApiError extends createTaggedError({
+  name: "UserApiError",
+  message: "User API $reason: $detail",
+}) {}
+
+const mapUserError = {
+  404: ({ statusCode }) => new UserApiError({ detail: `HTTP ${statusCode}`, reason: "not-found" }),
+  http: ({ statusCode }) => new UserApiError({ detail: `HTTP ${statusCode}`, reason: "http" }),
+  invalidJson: ({ cause }) =>
+    new UserApiError({ cause, detail: cause.message, reason: "invalid-json" }),
+  request: ({ cause }) => new UserApiError({ cause, detail: cause.message, reason: "request" }),
+  validation: ({ errors }) =>
+    new UserApiError({
+      detail: `${errors.length} validation issue(s)`,
+      reason: "validation",
+    }),
+} satisfies RequestJsonMapError;
+
+const user = requestJsonZod({
+  request: () => fetch(`https://example.com/users/${userId}`),
+  schema: userSchema,
+  mapError: mapUserError,
+  retry: {
+    times: 2,
+    delayMs: ({ nextAttempt }) => nextAttempt * 100,
+    jittered: 0.2,
+  },
+});
+```
+
+Use `z.output`, not `z.input` or an independently maintained interface, because Zod transforms can
+change the success type.
+
+## Map Request Errors
+
+Without `mapError`, request helpers return the package's `RequestError` union. Use that union for
+infrastructure-local code. At an application boundary, use `mapError` to convert these categories
+to concrete tagged errors:
+
+- request creation, network, or fetch failure;
+- status-specific HTTP failure, with numeric handlers taking precedence over `http`;
+- invalid JSON;
+- response validation or decode failure.
+
+Preserve `cause` for request and JSON failures and preserve status, URL, validation details, and
+other safe context needed for diagnosis. Do not map every category to a message-only `Error`.
+
+## Apply Retry Correctly
+
+```ts
+const user = requestJsonZod({
+  request: () => fetch(`https://example.com/users/${userId}`),
+  schema: userSchema,
+  retry: {
+    times: 2,
+    delayMs: ({ nextAttempt }) => nextAttempt * 100,
+    jittered: 0.2,
+  },
+});
+```
+
+The default policy retries request failures and HTTP `5xx`, but not `4xx`, invalid JSON, or
+validation failures. Retry requires a request factory; an already-created promise cannot be
+restarted. Ensure each attempt receives a fresh request. The current request retry configuration
+does not expose ResultAsync's internal retry signal, so do not claim that `requestJson`
+automatically forwards policy cancellation. Supply an external fetch signal through the request
+closure when the caller owns separate cancellation.
+
+## Validate In The Preferred Order
+
+1. Run the `resultar-check` CLI as the authoritative local and CI gate. It runs TypeScript first and
+   then all Resultar rules over the project.
+2. Configure the `resultar-check` TypeScript language-service plugin for equivalent diagnostics
+   while editing, using the workspace TypeScript version.
+3. Add Oxlint, ESLint, or Deno Lint only for optional low-latency AST-only feedback.
+4. Run the repository's formatter, build, tests, static analysis, package smoke tests, and runnable
+   examples.
+
+Do not claim that an AST-only lint pass replaced the CLI. The adapters intentionally expose fewer
+rules because they do not have TypeScript type information.
+
+## Configure The CLI And Language Server
+
+Install a project-local TypeScript 7+ and Resultar Check:
+
+```sh
+pnpm add -D resultar-check "typescript@>=7"
+pnpm exec resultar-check
+```
+
+Add the plugin to `tsconfig.json` and tune rules only when project policy requires it:
+
+```json
+{
+  "$schema": "./node_modules/resultar-check/schema.json",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "resultar-check",
+        "noDiscard": "error",
+        "noUnsafeAwait": "error",
+        "preferAndThen": "error",
+        "preferMapErr": "error",
+        "unsafeResultTypeAssertion": "error"
+      }
+    ]
+  }
+}
+```
+
+Use the workspace TypeScript SDK in the editor, make sure the plugin can resolve from the workspace
+`node_modules`, then restart the TypeScript server. A working setup reports source `resultar` and
+messages such as `[resultar/noDiscard]`. The corresponding lint rule ID is
+`resultar/no-discard`.
+
+Read `packages/check/README.md` for current VS Code, Zed/vtsls, and other editor setup. Use narrow
+`ignoreFilePatterns` only for deliberate tests, scripts, generated files, or terminal process
+boundaries.
+
+## Use Lint Adapters As Secondary Feedback
+
+Oxlint, ESLint, and Deno Lint adapters expose the shared syntax-only rules. Add the adapter that
+matches the project's existing lint host after the CLI and language server are working. Keep rule
+IDs aligned across surfaces, but expect type-aware rules such as unsafe error-channel narrowing to
+remain CLI/language-server responsibilities.
+
+When an agent encounters a diagnostic, fix the architecture first:
+
+- handle or explicitly discard a returned Resultar value;
+- replace nested `Result` from `map` with `andThen`;
+- replace error-only recovery with `mapErr`;
+- replace project-wide `try/catch` with `tryResult` or `tryResultAsync` when `noTryCatch` is enabled;
+- wrap raw promise awaits in Resultar contexts;
+- use `yield*` and avoid `try/catch` inside `safeTry`;
+- preserve the inferred error channel instead of asserting it away.
+
+## Discover Repository Commands
+
+Inspect `package.json` scripts instead of assuming a package manager or command. In the Resultar
+repository, the relevant root commands currently include:
+
+```sh
+pnpm fmt:check
+pnpm build
+pnpm check
+pnpm test
+pnpm analyze
+pnpm smoke:package
+pnpm test:examples
+```
+
+Run the narrowest useful command while iterating, then the complete relevant validation set before
+claiming completion. Report pre-existing dependency, lockfile, or environment blockers separately
+from failures introduced by the skill work.

--- a/skills/resultar/references/patterns.md
+++ b/skills/resultar/references/patterns.md
@@ -1,198 +1,244 @@
-# Resultar Patterns
+# Resultar Implementation Patterns
 
-Copy these patterns when implementing Resultar-based flows.
+Use these patterns as starting points, then align names and types with the consuming domain.
 
-## Validate Then Transform
+## Contents
+
+- [Model A Domain Failure](#model-a-domain-failure)
+- [Compose Sync And Async Steps](#compose-sync-and-async-steps)
+- [Write A Linear Workflow](#write-a-linear-workflow)
+- [Wrap External Work](#wrap-external-work)
+- [Apply Retry And Timeout Policy](#apply-retry-and-timeout-policy)
+- [Process Batches](#process-batches)
+- [Acquire And Release Resources](#acquire-and-release-resources)
+- [Recover Locally And Match At Boundaries](#recover-locally-and-match-at-boundaries)
+- [Add Observability](#add-observability)
+- [Migrate Incrementally](#migrate-incrementally)
+- [Test Runtime And Type Behavior](#test-runtime-and-type-behavior)
+
+## Model A Domain Failure
 
 ```ts
-import type { StrictResult } from 'resultar'
-
-import { createTaggedError, ok } from 'resultar'
+import { createTaggedError, ok } from "resultar";
+import type { StrictResult } from "resultar";
 
 class InvalidEmailError extends createTaggedError({
-  name: 'InvalidEmailError',
-  message: 'Invalid email $email',
+  name: "InvalidEmailError",
+  message: "Invalid email $email",
 }) {}
 
 const validateEmail = (email: string): StrictResult<string, InvalidEmailError> =>
-  email.includes('@') ? ok(email) : InvalidEmailError.err({ email })
-
-const normalizeEmail = (email: string): StrictResult<string, InvalidEmailError> =>
-  validateEmail(email).map((value) => value.trim().toLowerCase())
+  email.includes("@") ? ok(email.trim().toLowerCase()) : InvalidEmailError.err({ email });
 ```
 
-## Compose Domain Steps
+Use real tagged errors when the failure crosses a service, HTTP, job, queue, CLI, or integration
+boundary. Keep strings, enums, or `TaggedEnum` variants for intentionally local flows.
+
+## Compose Sync And Async Steps
 
 ```ts
-type CreateUserError = InvalidEmailError | UserAlreadyExistsError | DatabaseError
+type CreateUserError = InvalidEmailError | UserAlreadyExistsError | SaveUserError;
 
-const createUser = (email: string): StrictResult<User, CreateUserError> =>
-  validateEmail(email).andThen(ensureUserDoesNotExist).andThen(insertUser)
+const createUser = (input: CreateUserInput): StrictResultAsync<User, CreateUserError> =>
+  validateEmail(input.email)
+    .asyncAndThen(ensureEmailAvailable)
+    .andThen((email) => saveUser({ ...input, email }));
 ```
 
-Keep each step's error type specific. Let composition widen the final error union.
+- Use `map` only for an infallible value transform.
+- Use `filterOrElse` for predicate validation.
+- Use `andThen` when the next operation can fail.
+- Use `asyncAndThen` only for the sync-to-async bridge.
+- Keep each function's error type narrow and allow the final union to be inferred.
 
-## Compose Async Steps
-
-```ts
-import type { StrictResultAsync } from 'resultar'
-
-const createUser = (email: string): StrictResultAsync<User, CreateUserError> =>
-  validateEmail(email).asyncAndThen(ensureUserDoesNotExistAsync).andThen(insertUserAsync)
-```
-
-Use `asyncAndThen` when starting from `Result`, and `andThen` once already inside `ResultAsync`.
-
-## Use safeTry For Linear Control Flow
+## Write A Linear Workflow
 
 ```ts
-const createUser = (email: string): StrictResult<User, CreateUserError> =>
-  safeTry(function* () {
-    const validEmail = yield* validateEmail(email)
-    const user = yield* insertUser(validEmail)
-
-    return ok(user)
-  })
-```
-
-For async flows:
-
-```ts
-import type { StrictResultAsync } from 'resultar'
-
-const createUser = (email: string): StrictResultAsync<User, CreateUserError> =>
+const createUser = (input: CreateUserInput): StrictResultAsync<User, CreateUserError> =>
   safeTry(async function* () {
-    const validEmail = yield* validateEmail(email)
-    const user = yield* insertUserAsync(validEmail)
+    const email = yield* validateEmail(input.email);
+    yield* ensureEmailAvailable(email);
+    const user = yield* saveUser({ ...input, email });
 
-    return ok(user)
-  })
+    return ok(user);
+  });
 ```
 
-Prefer `yield* result` over `yield* result.safeUnwrap()`.
+Use `yield*` for every fallible Resultar step. Wrap an uncontrolled promise with
+`tryResultAsync` before yielding it. Do not mix raw `await` or broad `try/catch` into the generator.
 
-## Handle Errors At Boundaries
-
-```ts
-const toHttpResponse = (result: StrictResult<User, CreateUserError>) =>
-  result.matchTags((user) => ({ body: user, statusCode: 201 }), {
-    InvalidEmailError: (error) => ({
-      body: { code: error._tag, message: error.message },
-      statusCode: 400,
-    }),
-    UserAlreadyExistsError: (error) => ({
-      body: { code: error._tag, message: error.message },
-      statusCode: 409,
-    }),
-    DatabaseError: (error) => ({
-      body: { code: error._tag, message: error.message },
-      statusCode: 500,
-    }),
-  })
-```
-
-This keeps domain code free from transport concerns.
-
-## Recover Tagged Errors Locally
-
-Use `catchTag` when one tagged error can be recovered before a boundary.
+## Wrap External Work
 
 ```ts
-const result = createUser(email).catchTag('InvalidEmailError', (error) =>
-  ok({ email: error.email, id: 'draft_user' }),
-)
-```
-
-Use `catchTags` when a small set of tagged errors share a local recovery path.
-
-```ts
-const result = createUser(email).catchTags({
-  InvalidEmailError: (error) => ok({ email: error.email, id: 'draft_user' }),
-  UserAlreadyExistsError: (error) => ok({ email: error.email, id: 'existing_user' }),
-})
-```
-
-`catchTags` is already partial: unhandled tags remain in the `Err` side. Do not introduce or
-recommend `partialCatchTags`; reserve partial naming for boundary matching with a fallback.
-
-## Pipe Reusable Combinators
-
-Use `pipe` for Result helpers that are clearer as reusable functions than as nested method chains.
-
-```ts
-const audit = <T, E>(result: Result<T, E>): Result<T, E> =>
-  result.tap((value) => logger.info(value))
-
-const result = createUser(email).pipe(audit, (userResult) => userResult.map((user) => user.id))
-```
-
-Do not make `Result` directly iterable for tuple destructuring; `Result` iteration is reserved for `safeTry`.
-
-## Model Lightweight Tagged Domain Variants
-
-Use `TaggedEnum` when a tagged union should be structured but not an `Error`.
-
-```ts
-type PaymentState = TaggedEnum<{
-  Declined: { readonly code: string }
-  Pending: { readonly retryAfterMs: number }
-  Settled: { readonly receiptId: string }
-}>
-```
-
-Use `createTaggedError` instead when the value needs `message`, `cause`, `toJSON`, `.err()`, or
-`matchError`.
-
-Keep `TaggedEnum`, strings, enums, and lightweight objects for narrow local flows. Use
-`createTaggedError` and `StrictResult` when a failure crosses an application, service, HTTP, job, or
-integration boundary.
-
-## Wrap External Promises
-
-```ts
-class UpstreamError extends createTaggedError({
-  name: 'UpstreamError',
-  message: 'Upstream $service failed',
+class ProfileApiError extends createTaggedError({
+  name: "ProfileApiError",
+  message: "Profile API failed for $userId",
 }) {}
 
-const loadProfile = (id: string): StrictResultAsync<Profile, UpstreamError> =>
-  fromPromise(
-    client.getProfile(id),
-    (cause) => new UpstreamError({ cause, service: 'profile-api' }),
-  )
+type LoadProfileOptions = {
+  readonly attempt?: number;
+  readonly signal?: AbortSignal;
+};
+
+const loadProfile = (
+  userId: string,
+  options: LoadProfileOptions = {},
+): StrictResultAsync<Profile, ProfileApiError> =>
+  tryResultAsync(
+    () => profileClient.load(userId, options),
+    (cause) => new ProfileApiError({ cause, userId }),
+  );
 ```
 
-Use `tryCatchAsync(() => promiseFactory())` when the factory itself can throw synchronously.
+Prefer a promise factory because creating the promise may throw synchronously. Use
+`fromPromise(existingPromise, mapper)` only when the promise already exists, and use
+`fromSafePromise` only when non-rejection is guaranteed by contract.
 
-## Add Observability Without Changing Results
+For callback or subscription APIs, use `fromCallback` and return cleanup from `subscribe`:
 
 ```ts
-const result = loadProfile(id)
-  .tap((profile) => metrics.increment('profile.loaded', { id: profile.id }))
-  .tapError((error) => metrics.increment('profile.failed', { tag: error.name }))
-  .log((profile, error) => logger.info({ error, profile }, 'profile result'))
+const message = fromCallback<Message, SubscriptionError>({
+  catch: (cause) => new SubscriptionError({ cause, topic }),
+  signal,
+  subscribe: ({ resolve, reject }) => {
+    const subscription = client.subscribe(topic, resolve, reject);
+
+    return () => subscription.close();
+  },
+});
 ```
 
-Use these helpers only for side effects. They intentionally ignore callback failures. For Node.js 24
-explicit resource management, prefer `toDisposable(fn)` or `toAsyncDisposable(fn)` when cleanup
-should run at the end of a `using` / `await using` scope. Disposable cleanup callbacks are
-best-effort too.
+Check the installed `ResultAsyncFromCallbackOptions` type for exact client integration details.
+
+## Apply Retry And Timeout Policy
+
+```ts
+const profile = ResultAsync.timeout(
+  (signal) =>
+    ResultAsync.retry(
+      (attempt, retrySignal) => loadProfile(userId, { attempt, signal: retrySignal }),
+      {
+        times: 2,
+        delayMs: ({ nextAttempt }) => nextAttempt * 100,
+        jittered: 0.2,
+        while: (error) => error._tag === "ProfileApiError",
+        signal,
+      },
+    ),
+  {
+    timeoutMs: 1_500,
+    onTimeout: () => new ProfileTimeoutError({ timeoutMs: 1_500, userId }),
+  },
+);
+```
+
+Forward the supplied signal into the underlying operation. Confirm whether the desired timeout
+covers each attempt or the complete retry budget, then nest the policies accordingly. Use
+`retryOrElse` only when fallback after exhaustion is domain policy.
+
+Choose races deliberately:
+
+- `race` / `raceAll`: first settled `Ok` or `Err` wins.
+- `raceFirst`: first `Ok` wins; both must fail before an `Err` is returned.
+- `raceWith`: winner-specific logic needs access to the still-running task.
+
+## Process Batches
+
+Stop at the first error with bounded concurrency:
+
+```ts
+const saved = ResultAsync.forEach(rows, saveRow, { concurrency: 8 });
+```
+
+Collect all independent errors instead:
+
+```ts
+const validated = ResultAsync.validateAll(rows, validateRow, { concurrency: 8 });
+```
+
+Use `{ discard: true }` with `forEach` when successful values are intentionally unused. Do not
+silently discard the returned `ResultAsync` itself.
+
+## Acquire And Release Resources
+
+```ts
+const imported = ResultAsync.withResource({
+  acquire: (signal) => openImportSession({ signal }),
+  use: (session, signal) => importRows(session, rows, { signal }),
+  release: (session) => session.close(),
+});
+```
+
+Release runs after every successful acquire path, but release failures are best-effort. If cleanup
+failure must affect the returned result, include that operation in `use` or otherwise model it as a
+typed Resultar step.
+
+## Recover Locally And Match At Boundaries
+
+Recover only where the fallback is part of application policy:
+
+```ts
+const profile = loadProfile(userId).catchTags({
+  ProfileNotFoundError: () => ok(defaultProfile),
+  ProfileDisabledError: () => ok(disabledProfile),
+});
+```
+
+Unhandled tags remain in the error channel. At the HTTP boundary, map the complete union:
+
+```ts
+const response = await createUser(input).matchTags((user) => ({ body: user, statusCode: 201 }), {
+  InvalidEmailError: (error) => ({ body: error.toJSON(), statusCode: 400 }),
+  UserAlreadyExistsError: (error) => ({ body: error.toJSON(), statusCode: 409 }),
+  SaveUserError: (error) => ({ body: error.toJSON(), statusCode: 500 }),
+});
+```
+
+Use `matchTagsPartial` only when a shared fallback is intentional. Keep HTTP status codes out of
+domain functions.
+
+## Add Observability
+
+```ts
+const observed = loadProfile(userId)
+  .tap((profile) => metrics.increment("profile.loaded", { userId: profile.userId }))
+  .tapError((error) => metrics.increment("profile.failed", { tag: error._tag }))
+  .log((profile, error) => logger.info({ error, profile }, "profile result"));
+```
+
+These callbacks are best-effort and cannot change the result. Use `andThen` or `orElse` when a
+logging, auditing, publishing, or cleanup failure must affect control flow.
+
+## Migrate Incrementally
+
+1. Identify the outermost throwing or rejecting dependency.
+2. Create concrete tagged errors for expected domain and infrastructure failures.
+3. Wrap throws and rejections at that edge with `tryResult` or `tryResultAsync`.
+4. Change callers to compose with `map`, `andThen`, `asyncAndThen`, and `mapErr`.
+5. Move transport conversion to one boundary matcher.
+6. Replace broad error types and unsafe casts with inferred unions.
+7. Enable `resultar-check` rules and remove narrow temporary exceptions.
+
+Avoid converting the whole codebase in one unsafe cast. A wrapper at an integration seam lets the
+typed error channel spread in reviewable steps.
 
 ## Test Runtime And Type Behavior
 
 ```ts
-import { equal, ok as isTrue } from 'node:assert'
-import { describe, expectTypeOf, it } from 'vite-plus/test'
+import { equal, ok as assert } from "node:assert";
+import { describe, expectTypeOf, it } from "vite-plus/test";
 
-describe('validateEmail', () => {
-  it('returns typed tagged errors', () => {
-    const result = validateEmail('bad')
+describe("validateEmail", () => {
+  it("returns a typed tagged error", () => {
+    const result = validateEmail("invalid");
 
-    isTrue(result.isErr())
-    expectTypeOf(result.error).toEqualTypeOf<InvalidEmailError>()
-    equal(result.error._tag, 'InvalidEmailError')
-  })
-})
+    assert(result.isErr());
+    equal(result.error._tag, "InvalidEmailError");
+    expectTypeOf(result.error).toEqualTypeOf<InvalidEmailError>();
+  });
+});
 ```
 
-Use `// @ts-expect-error` inside unreachable blocks for negative type tests.
+Test every expected error path, not just `Ok`. Add type tests for inferred unions, required tagged
+error props, narrowing, and exhaustive handlers. Use deterministic fake clocks, signals, and
+clients for retry, timeout, cancellation, race, concurrency, and cleanup tests.

--- a/skills/resultar/references/review-checklist.md
+++ b/skills/resultar/references/review-checklist.md
@@ -1,68 +1,117 @@
-# Resultar Review Checklist
+# Resultar Review And Migration Checklist
 
-Use this checklist when reviewing code that uses Resultar or when migrating thrown-error code to Resultar.
+Use this checklist for implementation reviews, migrations, documentation changes, and final
+validation. Report only issues supported by the installed Resultar version and repository evidence.
 
-## API Fit
+## Source And Scope
 
-- Expected domain failures return `Result` or `ResultAsync`.
-- Unexpected programmer errors may still throw.
-- Sync functions do not return `ResultAsync` unless they call async work.
-- Async functions do not return raw `Promise<T>` when failure is expected and typed.
-- Tagged errors are used when errors need stable `_tag`, metadata, JSON output, or exhaustive matching.
+- Confirm the installed `resultar`, request adapter, and `resultar-check` versions.
+- Inspect local exports, types, package README files, and runnable examples before suggesting an API.
+- Separate issues introduced by the change from pre-existing workspace or dependency problems.
+- Preserve unrelated changes in a dirty worktree.
 
-## Type Quality
+## Failure Model
 
-- Error unions are specific and not widened to `Error` too early.
-- `isOk()` and `isErr()` are used for narrowing when direct branching is clearer than `match`.
-- `matchTags` is used at `Result` boundaries with tagged-error unions.
-- `matchError` handlers cover every tagged error in the union when only an error value is available.
-- `matchTags` / `matchError` include an `Error` handler when plain or untagged `Error` is possible.
-- `matchErrorPartial` has a deliberate fallback.
-- `.err(props)` on tagged errors returns `Result<never, ErrorClass>` and composes naturally.
-- Tagged error templates do not use reserved variables: `_tag`, `name`, `message`,
-  `messageTemplate`, `fingerprint`, `stack`, or `cause`.
-- `TaggedEnum` is used only for non-Error tagged variants; use `createTaggedError` for actual errors.
+- Expected failures return `Result` or `ResultAsync`; programmer defects may still throw.
+- Application and integration boundaries prefer `StrictResult` / `StrictResultAsync`.
+- Tagged errors have stable names, useful metadata, inferred template props, and preserved causes.
+- Error unions remain concrete instead of widening early to `Error`, `unknown`, or a string.
+- `TaggedEnum` is limited to lightweight non-Error domain variants.
+- Sensitive metadata is redacted when serialization or logging could expose it.
 
 ## Composition
 
-- `map` is used only for infallible value transforms.
-- `mapErr` is used only for error transforms.
-- `filterOrElse` is used for predicate validation that preserves the value.
-- `andThen` is used for fallible composition.
-- `asyncAndThen` bridges `Result` into `ResultAsync`.
-- `catchTag` / `catchTags` are used for local tagged-error recovery.
-- `partialCatchTags` is not introduced; `catchTags` already leaves unhandled tags untouched.
-- `pipe` is used only when reusable combinators improve clarity.
-- `safeTry` is used for linear workflows where chains are harder to read.
-- `yield* result` and `yield* resultAsync` are preferred over `safeUnwrap()`.
+- `map` performs only infallible success transforms.
+- `mapErr` performs error-only transforms.
+- `filterOrElse` represents predicate validation.
+- `andThen` composes fallible steps; `asyncAndThen` is used for the sync-to-async bridge.
+- `orElse` recovers the whole error channel; `catchTag` / `catchTags` recover selected domain cases.
+- `safeTry` uses `yield*` for Resultar values and contains no raw `await` or broad `try/catch`.
+- Returned `Result` and `ResultAsync` values are handled or explicitly discarded by supported policy.
+- Type assertions do not narrow away possible errors.
 
-## Boundaries
+## Async Boundaries And Policy
 
-- Transport code converts `Result` into HTTP responses, CLI output, jobs, or logs.
-- Domain code does not know HTTP status codes unless that is actually the domain.
-- External promise APIs are wrapped with `fromPromise` or `tryCatchAsync`.
-- Throwing third-party calls are wrapped with `tryCatch` or `fromThrowable`.
+- External throws and rejections are wrapped once, close to the uncontrolled dependency.
+- Error mappers accept `unknown` and produce concrete errors with `cause`.
+- Promise factories use `tryResultAsync`; already-created promises use `fromPromise`.
+- `fromSafePromise` is used only when rejection is impossible by contract.
+- Callback integrations provide cleanup and model `AbortError` where applicable.
+- Retry policy defines bounded attempts, delay/jitter, retryable errors, and cancellation.
+- Timeout scope is explicit: per attempt or across the complete retry budget.
+- `race`/`raceAll` are used for first settlement; `raceFirst` for first success.
+- Signals reach the underlying client so cancellation is cooperative rather than cosmetic.
+- Batch concurrency is bounded when workload size or dependency capacity requires it.
+- `validateAll` is used only when collecting all independent failures is desired.
+- `withResource` cleanup is treated as best-effort; important cleanup failures are modeled in the
+  result channel.
 
-## Observability
+## Boundaries And Recovery
 
-- `tap`, `tapError`, and `log` are used only for observation.
-- `toDisposable` and `toAsyncDisposable` are used for scoped cleanup.
-- Callback failures in side-effect helpers are not expected to alter control flow.
-- Fallible side effects that matter are modeled with `andThen`, `orElse`, or `tryCatch`.
+- Domain code does not contain transport status codes, framework responses, or CLI exit behavior.
+- `matchTags` handles the complete tagged error union at the boundary.
+- `matchTagsPartial` and `matchErrorPartial` have intentional fallbacks.
+- An `Error` handler exists when untagged errors can reach tagged matching.
+- Recovery is local only when the fallback is genuine domain/application policy.
+- `_unsafeUnwrap*` remains in tests; `runSync`, `runPromise`, and `unwrapOrThrow` appear only at
+  deliberate terminal boundaries.
 
-## Tests
+## HTTP Requests
 
-- Runtime tests cover success and failure paths.
-- Type tests cover inferred tagged-error props and exhaustive handlers.
-- Tests use `vite-plus/test` in the Resultar repository.
-- `_unsafeUnwrap()` and `_unsafeUnwrapErr()` are kept in tests, not application code.
+- `resultar-request` is used for a custom guard/decoder; TypeBox and Zod use their dedicated
+  adapters.
+- TypeBox success types derive from `Static<typeof schema>`.
+- Zod success types derive from `z.output<typeof schema>` so transforms are preserved.
+- Validated values are not widened back to `JsonRecord`, `Record<string, unknown>`, or `unknown`.
+- Error mapping distinguishes request, HTTP, invalid-JSON, and validation failures.
+- Numeric HTTP handlers take precedence over generic HTTP mapping where needed.
+- Retry uses a request factory and does not retry non-retryable `4xx`, JSON, or validation failures
+  without explicit policy.
 
-## Red Flags
+## Observability And Cleanup
 
-- Returning `T | Error` from functions that should use Resultar.
-- Catching errors and returning strings without typed structure.
-- Calling `_unsafeUnwrap()` in production code.
-- Creating tagged errors without using the generated constructor props.
-- Depending on spoofed `_tag` objects passing `ErrorClass.is`; guards are nominal.
-- Swallowing domain errors by converting everything to `Error` too early.
-- Using `tap` to perform fallible work that should affect the returned result.
+- `tap`, `tapError`, and `log` are used only for best-effort observation.
+- Callback failure in observation helpers is not expected to change the result.
+- Audits, publishes, or cleanup that must succeed use `andThen`, `orElse`, or another Resultar
+  boundary.
+- Logs expose stable tags and safe context without leaking redacted values.
+
+## Tests And Documentation
+
+- Runtime tests cover `Ok` and every expected `Err` branch.
+- Type tests cover inferred error unions, required tagged-error props, narrowing, and exhaustive
+  handlers.
+- Retry, timeout, cancellation, races, concurrency, and cleanup use deterministic fakes.
+- Tests use the repository's actual runner; this repository uses `vite-plus/test`.
+- Documentation examples compile or have a matching runnable example.
+- Core request, TypeBox, and Zod docs link to one another as alternatives/adapters.
+- API names, package links, and version claims match current source.
+
+## Validation Order
+
+1. Run the `resultar-check` CLI as the authoritative project check.
+2. Confirm the TypeScript language-service plugin uses the workspace TypeScript version and emits
+   Resultar diagnostics in the editor.
+3. Run Oxlint, ESLint, or Deno Lint only as optional AST-only feedback.
+4. Run formatting, build, tests, analysis, package smoke tests, and example workflows that apply.
+5. Report exactly which commands passed, failed, or were blocked.
+
+## Review Red Flags
+
+- `T | Error`, sentinel `null`, message strings, or thrown expected failures replace a Resultar
+  channel.
+- A broad `try/catch` surrounds an entire workflow instead of wrapping one external boundary.
+- Project-wide `try/catch` remains after the strict `noTryCatch` migration rule is enabled.
+- `map` returns another `Result` or `ResultAsync`.
+- `orElse` only replaces one error with another and should be `mapErr`.
+- A raw promise is awaited inside a Resultar workflow without a typed mapper.
+- `safeTry` contains raw `await`, plain `yield`, `try/catch`, or legacy `safeUnwrap()`.
+- A Resultar value is created and ignored.
+- `_unsafeUnwrap()` appears in production code.
+- An assertion makes an error union narrower than the implementation can guarantee.
+- Tagged errors override generated constructors, mismatch class names, or omit useful causes.
+- A schema adapter returns a broad JSON type or duplicates the schema with a drifting interface.
+- A promise rather than a request factory is configured for retry.
+- Hand-written retry, timeout, or race logic duplicates a built-in ResultAsync policy.
+- A lint-only pass is described as full Resultar validation.
+- Documentation recommends an API absent from the installed package.


### PR DESCRIPTION
## Summary

- expand the Resultar, request, TypeBox, and Zod documentation with cross-links and richer request examples
- upgrade the repo-local Resultar AI skill with current v3.5 workflows, integration guidance, review rules, evaluations, and generated UI metadata
- add the opt-in `resultar/no-try-catch` rule across the CLI, TypeScript language service, Oxlint, ESLint, and Deno Lint
- bump `resultar-check` to `2.2.0` and update its changelog
- refresh workspace tooling, including Vite+ `0.2.4` and catalog-managed Oxlint `1.74.0`

## Why

Request adapters and validation surfaces were difficult to discover from the package READMEs, and AI agents lacked one canonical guide for implementing and reviewing typed Resultar workflows. The checker also needed an explicit, opt-in way to discourage raw `try/catch` for expected failures while preserving `try/finally` cleanup.

## Impact

Consumers get clearer package-selection and request-validation examples. AI agents get an opinionated Resultar engineering workflow. Projects can enable `resultar/no-try-catch` consistently across the authoritative CLI/language-server path and optional syntax-only lint adapters.

The new diagnostic is opt-in, so existing consumers are not forced into a behavior change.

## Validation

- `pnpm check:full` — 545 tests, formatting, linting, coverage, and static analysis
- `pnpm smoke:package`
- `pnpm test:examples`
- `pnpm example:oxlint` with Oxlint 1.74.0
- `pnpm install --frozen-lockfile`
- `pnpm --filter resultar-check smoke:package` after the 2.2.0 version bump
- `git diff --check`
