### PR TITLE
Improve JSR package scores

### DIFF
--- a/.changeset/bright-jsr-docs.md
+++ b/.changeset/bright-jsr-docs.md
@@ -1,0 +1,8 @@
+---
+"resultar": patch
+"resultar-request": patch
+"resultar-request-typebox": patch
+"resultar-request-zod": patch
+---
+
+Document the JSR entrypoints and exported symbols used by Resultar and its request packages.

--- a/.changeset/clean-check-docs.md
+++ b/.changeset/clean-check-docs.md
@@ -1,0 +1,5 @@
+---
+"resultar-check": patch
+---
+
+Document every JSR entrypoint and exported symbol so the registry can generate complete API documentation.

--- a/packages/check/src/deno/plugin.ts
+++ b/packages/check/src/deno/plugin.ts
@@ -1,3 +1,12 @@
+/**
+ * Deno Lint adapter for Resultar's syntax-only rules.
+ *
+ * Add the default export to `plugins` in `deno.json`. Keep the
+ * `resultar-check` CLI as the authoritative type-aware project gate.
+ *
+ * @module
+ */
+
 import { rules } from "../rules.js";
 
 export type {
@@ -8,11 +17,15 @@ export type {
   RuleReportDescriptor,
 } from "../rules.js";
 
+/** Public shape of the Resultar Deno Lint plugin. */
 export interface DenoLintPlugin {
+  /** Plugin namespace used by Deno Lint. */
   readonly name: string;
+  /** Syntax-only Resultar rules exposed to Deno Lint. */
   readonly rules: typeof rules;
 }
 
+/** Ready-to-use Resultar plugin for Deno Lint. */
 const plugin: DenoLintPlugin = { name: "resultar", rules };
 
 export default plugin;

--- a/packages/check/src/diagnostics.ts
+++ b/packages/check/src/diagnostics.ts
@@ -1,3 +1,12 @@
+/**
+ * TypeScript diagnostics for enforcing Resultar handling rules.
+ *
+ * Use these helpers to run the same type-aware diagnostics exposed by the
+ * `resultar-check` CLI and TypeScript language-service plugin.
+ *
+ * @module
+ */
+
 import type * as ts from "./typescript-api.js";
 
 import type { ResultarLintFinding, ResultarRuleName, ResultarRuleSeverity } from "./finding.js";
@@ -9,8 +18,13 @@ import {
 } from "./rules-core.js";
 import { shouldInspectSourceFile } from "./source-files.js";
 
+/** Stable diagnostic source reported to TypeScript clients. */
 export const RESULTAR_DIAGNOSTIC_SOURCE = "resultar";
+
+/** TypeScript diagnostic code assigned to the `resultar/no-discard` rule. */
 export const RESULTAR_NO_DISCARD_DIAGNOSTIC_CODE = 91_001;
+
+/** TypeScript diagnostic code assigned to each Resultar rule. */
 export const RESULTAR_RULE_DIAGNOSTIC_CODES: Record<ResultarRuleName, number> = {
   "no-await-in-safe-try": 91_014,
   "no-discard": RESULTAR_NO_DISCARD_DIAGNOSTIC_CODE,
@@ -38,10 +52,15 @@ interface DiagnosticContext {
   readonly tsApi: TypeScriptApi;
 }
 
+/** Inputs required to inspect one TypeScript source file. */
 export interface ResultarDiagnosticInput {
+  /** Resultar rule configuration, usually read from `compilerOptions.plugins`. */
   readonly options?: ResultarLanguageServiceOptions;
+  /** TypeScript program that owns the source file. */
   readonly program: ts.Program;
+  /** Source file to inspect. */
   readonly sourceFile: ts.SourceFile;
+  /** TypeScript API instance associated with the program. */
   readonly tsApi: TypeScriptApi;
 }
 
@@ -81,6 +100,11 @@ const createResultarDiagnostic = (
   };
 };
 
+/**
+ * Returns all enabled Resultar diagnostics for one source file.
+ *
+ * Files excluded by `ignoreFilePatterns` produce an empty diagnostic list.
+ */
 export const getResultarDiagnostics = (
   input: ResultarDiagnosticInput,
 ): readonly ts.Diagnostic[] => {
@@ -101,6 +125,7 @@ export const getResultarDiagnostics = (
   return diagnostics;
 };
 
+/** Returns all enabled Resultar diagnostics across a TypeScript program. */
 export const getProgramResultarDiagnostics = (
   tsApi: TypeScriptApi,
   program: ts.Program,
@@ -110,6 +135,7 @@ export const getProgramResultarDiagnostics = (
     .getSourceFiles()
     .flatMap((sourceFile) => getResultarDiagnostics({ options, program, sourceFile, tsApi }));
 
+/** Returns only `resultar/no-discard` diagnostics for one source file. */
 export const getNoDiscardDiagnostics = (input: ResultarDiagnosticInput): readonly ts.Diagnostic[] =>
   getResultarDiagnostics({
     ...input,
@@ -120,6 +146,7 @@ export const getNoDiscardDiagnostics = (input: ResultarDiagnosticInput): readonl
     },
   });
 
+/** Returns only `resultar/no-discard` diagnostics across a TypeScript program. */
 export const getProgramNoDiscardDiagnostics = (
   tsApi: TypeScriptApi,
   program: ts.Program,

--- a/packages/check/src/eslint/plugin.ts
+++ b/packages/check/src/eslint/plugin.ts
@@ -1,3 +1,12 @@
+/**
+ * ESLint adapter for Resultar's syntax-only rules.
+ *
+ * Use the default export in an ESLint flat config. Keep the `resultar-check`
+ * CLI as the authoritative type-aware project gate.
+ *
+ * @module
+ */
+
 import { recommendedSeverities, rules } from "../rules.js";
 
 export type {
@@ -8,14 +17,21 @@ export type {
   RuleReportDescriptor,
 } from "../rules.js";
 
+/** Minimal ESLint flat-config shape used by the Resultar adapter. */
 export interface LinterConfig {
+  /** Plugins available to rules in this config. */
   readonly plugins?: Record<string, unknown>;
+  /** Configured rule severities keyed by qualified rule name. */
   readonly rules?: Record<string, "error" | "off" | "warn">;
 }
 
+/** Public shape of the Resultar ESLint plugin. */
 export interface ResultarLintPlugin {
+  /** Shareable configurations provided by the plugin. */
   readonly configs: { recommended?: LinterConfig };
+  /** Plugin metadata consumed by ESLint. */
   readonly meta: { readonly name: string };
+  /** Syntax-only Resultar rules exposed to ESLint. */
   readonly rules: typeof rules;
 }
 
@@ -31,6 +47,7 @@ const createRecommendedRules = (): Record<string, "error" | "warn"> => {
 
 const recommendedRules = createRecommendedRules();
 
+/** Ready-to-use Resultar plugin for ESLint flat config. */
 const plugin: ResultarLintPlugin = { configs: {}, meta: { name: "resultar-check" }, rules };
 
 const recommended: LinterConfig = { plugins: { resultar: plugin }, rules: recommendedRules };

--- a/packages/check/src/rules.ts
+++ b/packages/check/src/rules.ts
@@ -15,6 +15,7 @@ import {
   visitSameFunctionDescendants,
 } from "./core/ast.js";
 
+/** Rule names implemented by the Deno Lint and ESLint adapters. */
 export type ResultarLintRuleName =
   | "no-await-in-safe-try"
   | "no-tagged-error-constructor-override"
@@ -26,19 +27,28 @@ export type ResultarLintRuleName =
   | "typed-catch-mapper"
   | "yield-star-in-safe-try";
 
+/** A finding reported by a Resultar syntax-only lint rule. */
 export interface RuleReportDescriptor {
+  /** Human-readable guidance for resolving the finding. */
   readonly message: string;
+  /** AST node that caused the finding. */
   readonly node: AstNode;
 }
 
+/** Minimal lint-host context consumed by Resultar rule implementations. */
 export interface RuleContext {
+  /** Reports a finding to the active lint host. */
   readonly report: (descriptor: RuleReportDescriptor) => void;
 }
 
+/** AST visitor callbacks returned by a Resultar rule. */
 export type RuleListener = Record<string, (node: AstNode) => void>;
 
+/** Host-neutral shape of a Resultar syntax-only lint rule. */
 export interface ResultarRuleModule {
+  /** Creates the rule's AST listeners for a lint run. */
   readonly create: (context: RuleContext) => RuleListener;
+  /** Metadata consumed by Deno Lint and ESLint. */
   readonly meta: {
     readonly docs: { readonly description: string };
     readonly schema: readonly unknown[];
@@ -239,6 +249,7 @@ const noTaggedErrorConstructorOverride = createRule(
   "suggestion",
 );
 
+/** Syntax-only Resultar rules shared by the Deno Lint and ESLint adapters. */
 export const rules: Record<ResultarLintRuleName, ResultarRuleModule> = {
   "no-await-in-safe-try": noAwaitInSafeTry,
   "no-tagged-error-constructor-override": noTaggedErrorConstructorOverride,
@@ -251,6 +262,7 @@ export const rules: Record<ResultarLintRuleName, ResultarRuleModule> = {
   "yield-star-in-safe-try": yieldStarInSafeTry,
 };
 
+/** Recommended severity for each syntax-only Resultar rule. */
 export const recommendedSeverities: Record<ResultarLintRuleName, "error" | "warn"> = {
   "no-await-in-safe-try": "error",
   "no-tagged-error-constructor-override": "warn",

--- a/packages/request-typebox/src/index.ts
+++ b/packages/request-typebox/src/index.ts
@@ -1,5 +1,15 @@
+/**
+ * TypeBox schema adapter for `resultar-request`.
+ *
+ * @module
+ */
+
 export * from "resultar-request";
-export { requestJsonTypeBox, requestJsonTypeBox as requestJson } from "./request-json-typebox.js";
+export { requestJsonTypeBox } from "./request-json-typebox.js";
+
+/** Package-local alias for `requestJsonTypeBox`. */
+export { requestJsonTypeBox as requestJson } from "./request-json-typebox.js";
+
 export type {
   RequestJsonTypeBoxInput,
   RequestJsonTypeBoxMappedInput,

--- a/packages/request-typebox/src/request-json-typebox.ts
+++ b/packages/request-typebox/src/request-json-typebox.ts
@@ -11,11 +11,13 @@ import {
   type RequestError,
 } from "resultar-request";
 
+/** Request input validated by a TypeBox schema. */
 export type RequestJsonTypeBoxInput<
   S extends TSchema,
   R extends RequestJsonResponseData = RequestJsonResponseData,
 > = RequestJsonBaseInput<R> & { readonly schema: S };
 
+/** TypeBox request input with an explicit domain-error mapping. */
 export type RequestJsonTypeBoxMappedInput<
   S extends TSchema,
   M extends RequestJsonMapError,
@@ -25,6 +27,12 @@ export type RequestJsonTypeBoxMappedInput<
 const getTypeBoxErrors = (schema: TSchema, value: unknown) =>
   [...Value.Errors(schema, value)].map((error) => ({ message: error.message }));
 
+/**
+ * Executes a JSON request and validates the decoded value with TypeBox.
+ *
+ * The Ok type is inferred from `Static<S>`. Transport, HTTP, JSON, and validation failures use the
+ * core `resultar-request` error channel or the supplied `mapError` handlers.
+ */
 export function requestJsonTypeBox<
   S extends TSchema,
   M extends RequestJsonMapError,

--- a/packages/request-zod/src/index.ts
+++ b/packages/request-zod/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * Zod schema adapter for `resultar-request`.
+ *
+ * @module
+ */
+
 export * from "resultar-request";
-export { requestJsonZod, requestJsonZod as requestJson } from "./request-json-zod.js";
+export { requestJsonZod } from "./request-json-zod.js";
+
+/** Package-local alias for `requestJsonZod`. */
+export { requestJsonZod as requestJson } from "./request-json-zod.js";
+
 export type { RequestJsonZodInput, RequestJsonZodMappedInput } from "./request-json-zod.js";

--- a/packages/request-zod/src/request-json-zod.ts
+++ b/packages/request-zod/src/request-json-zod.ts
@@ -10,11 +10,13 @@ import {
   type RequestError,
 } from "resultar-request";
 
+/** Request input validated by a Zod schema. */
 export type RequestJsonZodInput<
   S extends z.ZodType,
   R extends RequestJsonResponseData = RequestJsonResponseData,
 > = RequestJsonBaseInput<R> & { readonly schema: S };
 
+/** Zod request input with an explicit domain-error mapping. */
 export type RequestJsonZodMappedInput<
   S extends z.ZodType,
   M extends RequestJsonMapError,
@@ -23,6 +25,12 @@ export type RequestJsonZodMappedInput<
 
 const toPath = (path: readonly PropertyKey[]) => path.map((part) => part);
 
+/**
+ * Executes a JSON request and validates the decoded value with Zod.
+ *
+ * The Ok type preserves `z.output<S>`. Transport, HTTP, JSON, and validation failures use the core
+ * `resultar-request` error channel or the supplied `mapError` handlers.
+ */
 export function requestJsonZod<
   S extends z.ZodType,
   M extends RequestJsonMapError,

--- a/packages/request/src/index.ts
+++ b/packages/request/src/index.ts
@@ -1,12 +1,22 @@
+/**
+ * Fetch-first JSON request helpers with typed Resultar failures, retries, decoding, and custom
+ * error mapping.
+ *
+ * @module
+ */
+
 export {
   HttpResponseErrorCauseError,
-  HttpResponseErrorCauseError as HttpClientRequestErrorCause,
   RequestError,
   baseRequestErrorHandler,
   integrationErrorHandler,
   isHttpResponseError,
   requestJson,
 } from "./request-json.js";
+
+/** Compatibility alias for `HttpResponseErrorCauseError`. */
+export { HttpResponseErrorCauseError as HttpClientRequestErrorCause } from "./request-json.js";
+
 export type {
   FetchJsonResponseData,
   RequestHeaders,

--- a/packages/request/src/request-json.ts
+++ b/packages/request/src/request-json.ts
@@ -42,6 +42,7 @@ type NormalizedJsonResponseData = {
 
 type ErrorWithName = Error & { readonly name: string };
 
+/** Error cause containing the body, headers, and status of an unsuccessful HTTP response. */
 export class HttpResponseErrorCauseError extends Error {
   readonly body: string;
   readonly headers: RequestHeaders;
@@ -74,6 +75,7 @@ class RequestJsonValidationErrorCauseError extends Error {
   }
 }
 
+/** Default request failure used when no domain-specific `mapError` configuration is supplied. */
 export class RequestError extends Error {
   constructor(
     message?: string,
@@ -101,8 +103,10 @@ export class RequestError extends Error {
   }
 }
 
+/** Request error whose cause contains an unsuccessful HTTP response. */
 export type HttpResponseError = RequestError & { readonly cause: HttpResponseErrorCauseError };
 
+/** Narrows a request error to an HTTP-response error with structured response metadata. */
 export const isHttpResponseError = (error: RequestError): error is HttpResponseError =>
   error.cause instanceof HttpResponseErrorCauseError;
 
@@ -112,9 +116,11 @@ const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
 const isErrorWithName = (exception: unknown): exception is ErrorWithName =>
   exception instanceof Error && typeof exception.name === "string";
 
+/** Maps an unknown integration failure to a 500 `RequestError`. */
 export const integrationErrorHandler = (exception: unknown): RequestError =>
   RequestError.integrationError(exception);
 
+/** Maps timeout failures to 408 and other unknown request failures to 500. */
 export const baseRequestErrorHandler = (exception: unknown): RequestError => {
   if (isErrorWithName(exception) && timeoutErrorNames.has(exception.name)) {
     return new RequestError(exception.message, 408, exception);
@@ -344,6 +350,12 @@ const executeRequestJson = <T, R extends RequestJsonResponseData = RequestJsonRe
   return mapError === undefined ? result : result.mapErr(mapRequestJsonError(mapError));
 };
 
+/**
+ * Executes a Fetch-compatible JSON request and returns decoded data through `ResultAsync`.
+ *
+ * Supply `decode` or `validator` for the response contract, `retry` for retryable request factories,
+ * and `mapError` when the service boundary needs domain-specific error types.
+ */
 export function requestJson<
   T,
   M extends RequestJsonMapError,

--- a/packages/request/src/types.ts
+++ b/packages/request/src/types.ts
@@ -2,8 +2,10 @@ import type { ResultAsyncRetryContext } from "resultar";
 
 import type { RequestError } from "./request-json.js";
 
+/** Header collection carried by a Fetch-compatible or Undici-compatible response. */
 export type RequestHeaders = unknown;
 
+/** Structural response contract accepted from the Fetch API. */
 export type FetchJsonResponseData = {
   readonly headers?: RequestHeaders;
   readonly json: () => Promise<unknown>;
@@ -11,28 +13,35 @@ export type FetchJsonResponseData = {
   readonly text: () => Promise<string>;
 };
 
+/** Structural response contract accepted from Undici request helpers. */
 export type UndiciJsonResponseData = {
   readonly body: { readonly json: () => Promise<unknown>; readonly text: () => Promise<string> };
   readonly headers?: RequestHeaders;
   readonly statusCode: number;
 };
 
+/** Fetch-compatible or Undici-compatible response accepted by `requestJson`. */
 export type RequestJsonResponseData = FetchJsonResponseData | UndiciJsonResponseData;
 
+/** Promise or retryable promise factory that produces a JSON response. */
 export type RequestJsonSource<R extends RequestJsonResponseData = RequestJsonResponseData> =
   | Promise<R>
   | (() => Promise<R>);
 
+/** Type guard used to validate a decoded JSON value. */
 export type RequestJsonValidator<T> = (value: unknown) => value is T;
 
+/** Structured issue returned by a JSON decoder or schema adapter. */
 export type RequestJsonValidationIssue = {
   readonly code?: string;
   readonly message: string;
   readonly path?: readonly PropertyKey[] | string;
 };
 
+/** Successful result returned by a JSON decoder. */
 export type RequestJsonDecodeSuccess<T> = { readonly success: true; readonly value: T };
 
+/** Failed result returned by a JSON decoder. */
 export type RequestJsonDecodeFailure = {
   readonly cause?: unknown;
   readonly errors?: readonly RequestJsonValidationIssue[];
@@ -40,16 +49,20 @@ export type RequestJsonDecodeFailure = {
   readonly success: false;
 };
 
+/** Success or failure returned by a JSON decoder. */
 export type RequestJsonDecodeResult<T> = RequestJsonDecodeFailure | RequestJsonDecodeSuccess<T>;
 
+/** Converts an unknown JSON value into a typed decode result. */
 export type RequestJsonDecoder<T> = (value: unknown) => RequestJsonDecodeResult<T>;
 
+/** Validation details used by validation messages and error mappers. */
 export type RequestJsonValidationReason = {
   readonly cause?: unknown;
   readonly errors: readonly RequestJsonValidationIssue[];
   readonly value: unknown;
 };
 
+/** Context supplied when an HTTP response has a 4xx or 5xx status. */
 export type RequestJsonHttpErrorContext = {
   readonly body: string;
   readonly error: RequestError;
@@ -57,33 +70,39 @@ export type RequestJsonHttpErrorContext = {
   readonly statusCode: number;
 };
 
+/** Context supplied when a successful response body is not valid JSON. */
 export type RequestJsonInvalidJsonErrorContext = {
   readonly cause: Error;
   readonly error: RequestError;
 };
 
+/** Context supplied when the request promise rejects. */
 export type RequestJsonRequestFailureContext = {
   readonly cause: Error;
   readonly error: RequestError;
 };
 
+/** Context supplied when decoded JSON does not satisfy the response contract. */
 export type RequestJsonValidationErrorContext = RequestJsonValidationReason & {
   readonly error: RequestError;
   readonly message: string;
 };
 
+/** Discriminated context passed to request error handlers. */
 export type RequestJsonErrorContext =
   | ({ readonly reason: "http" } & RequestJsonHttpErrorContext)
   | ({ readonly reason: "invalidJson" } & RequestJsonInvalidJsonErrorContext)
   | ({ readonly reason: "request" } & RequestJsonRequestFailureContext)
   | ({ readonly reason: "validation" } & RequestJsonValidationErrorContext);
 
+/** Error context plus retry-attempt metadata. */
 export type RequestJsonRetryContext =
   | (Extract<RequestJsonErrorContext, { readonly reason: "http" }> & ResultAsyncRetryContext)
   | (Extract<RequestJsonErrorContext, { readonly reason: "invalidJson" }> & ResultAsyncRetryContext)
   | (Extract<RequestJsonErrorContext, { readonly reason: "request" }> & ResultAsyncRetryContext)
   | (Extract<RequestJsonErrorContext, { readonly reason: "validation" }> & ResultAsyncRetryContext);
 
+/** Retry policy for a request factory. */
 export type RequestJsonRetry = {
   readonly delayMs?: number | ((context: ResultAsyncRetryContext) => number);
   readonly jittered?: number;
@@ -92,6 +111,7 @@ export type RequestJsonRetry = {
   readonly when?: (context: RequestJsonRetryContext) => boolean | Promise<boolean>;
 };
 
+/** Maps each request failure category, and optionally HTTP statuses, to domain errors. */
 export type RequestJsonMapError = Partial<
   Record<number, (context: RequestJsonHttpErrorContext) => Error>
 > & {
@@ -107,6 +127,7 @@ type RequestJsonStatusMapErrorResult<M extends RequestJsonMapError> = M[number] 
   ? E
   : never;
 
+/** Union of every error returned by a `RequestJsonMapError` configuration. */
 export type RequestJsonMapErrorResult<M extends RequestJsonMapError> =
   | ReturnType<M["http"]>
   | ReturnType<M["invalidJson"]>
@@ -114,8 +135,10 @@ export type RequestJsonMapErrorResult<M extends RequestJsonMapError> =
   | ReturnType<M["validation"]>
   | RequestJsonStatusMapErrorResult<M>;
 
+/** Static or computed message used when response validation fails. */
 export type RequestJsonValidationError = string | ((reason: RequestJsonValidationReason) => string);
 
+/** Options shared by validator, decoder, and schema-adapter requests. */
 export type RequestJsonBaseInput<R extends RequestJsonResponseData = RequestJsonResponseData> = {
   readonly mapError?: RequestJsonMapError;
   readonly request: RequestJsonSource<R>;
@@ -123,6 +146,7 @@ export type RequestJsonBaseInput<R extends RequestJsonResponseData = RequestJson
   readonly validationError?: RequestJsonValidationError;
 };
 
+/** Request input that validates JSON with a decoder. */
 export type RequestJsonDecodeInput<
   T,
   R extends RequestJsonResponseData = RequestJsonResponseData,
@@ -131,6 +155,7 @@ export type RequestJsonDecodeInput<
   readonly validator?: never;
 };
 
+/** Request input that validates JSON with a type guard. */
 export type RequestJsonValidatorInput<
   T,
   R extends RequestJsonResponseData = RequestJsonResponseData,
@@ -139,22 +164,26 @@ export type RequestJsonValidatorInput<
   readonly validator: RequestJsonValidator<T>;
 };
 
+/** Validator-based or decoder-based input accepted by `requestJson`. */
 export type RequestJsonInput<T, R extends RequestJsonResponseData = RequestJsonResponseData> =
   | RequestJsonDecodeInput<T, R>
   | RequestJsonValidatorInput<T, R>;
 
+/** Decoder input with an explicit domain-error mapping. */
 export type RequestJsonMappedDecodeInput<
   T,
   M extends RequestJsonMapError,
   R extends RequestJsonResponseData = RequestJsonResponseData,
 > = RequestJsonDecodeInput<T, R> & { readonly mapError: M };
 
+/** Validator input with an explicit domain-error mapping. */
 export type RequestJsonMappedValidatorInput<
   T,
   M extends RequestJsonMapError,
   R extends RequestJsonResponseData = RequestJsonResponseData,
 > = RequestJsonValidatorInput<T, R> & { readonly mapError: M };
 
+/** Mapped decoder or validator input accepted by `requestJson`. */
 export type RequestJsonMappedInput<
   T,
   M extends RequestJsonMapError,

--- a/packages/resultar/src/index.ts
+++ b/packages/resultar/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Typed synchronous and asynchronous error workflows built around `Result<T, E>` and
+ * `ResultAsync<T, E>`.
+ *
+ * @module
+ */
+
 export {
   DisposableResultAsync,
   errAsync,
@@ -10,9 +17,12 @@ export {
   runPromise,
   tryCatchAsync,
   tryResultAsync,
-  tryResultAsync as tryAsync,
   unitAsync,
 } from './result-async.js'
+
+/** Compatibility alias for `tryResultAsync`. */
+export { tryResultAsync as tryAsync } from './result-async.js'
+
 export type {
   ResultAsyncAbortSignal,
   ResultAsyncCallbackCleanup,
@@ -43,12 +53,17 @@ export {
   Result,
   runSync,
   safeTry,
-  tryResult as default,
-  tryResult as try,
   tryCatch,
   tryResult,
   unit,
 } from './result.js'
+
+/** Default compatibility export for `tryResult`. */
+export { tryResult as default } from './result.js'
+
+/** Compatibility alias for `tryResult`. */
+export { tryResult as try } from './result.js'
+
 export type {
   ErrResult,
   OkResult,

--- a/packages/resultar/src/result-async.ts
+++ b/packages/resultar/src/result-async.ts
@@ -72,6 +72,7 @@ export interface TryResultAsyncOptions<T, E = unknown> {
   readonly catch?: (e: unknown) => E
 }
 
+/** Minimal abort-signal contract used by cancellable Resultar operations. */
 export interface ResultAsyncAbortSignal {
   /**
    * Whether the cooperative async operation has been aborted.
@@ -177,6 +178,7 @@ type ResultAsyncRaceTasksOk<Tasks extends readonly ResultAsyncRaceTask<unknown, 
   ResultAsyncRaceTaskOk<Tasks[number]>
 type ResultAsyncRaceTasksErr<Tasks extends readonly ResultAsyncRaceTask<unknown, unknown>[]> =
   ResultAsyncRaceTaskErr<Tasks[number]>
+/** Running cancellable task returned by Resultar race helpers. */
 export interface ResultAsyncRaceHandle<T, E> {
   /**
    * Abort signal associated with the running task.
@@ -234,6 +236,7 @@ export type ResultAsyncRetryTask<T, E> = (
 type ResultAsyncRetryTaskOk<Task> = Task extends ResultAsyncRetryTask<infer T, unknown> ? T : never
 type ResultAsyncRetryTaskErr<Task> = Task extends ResultAsyncRetryTask<unknown, infer E> ? E : never
 type ResultAsyncRetryDelay = number | ((context: ResultAsyncRetryContext) => number)
+/** Retry policy for `ResultAsync.retry` and related helpers. */
 export interface ResultAsyncRetryOptions<E> {
   /**
    * Delay in milliseconds before retrying. Functions receive retry context.
@@ -1643,6 +1646,7 @@ const callAsyncSideEffect = async (effect: () => void | Promise<void>): Promise<
   }
 }
 
+/** Async-disposable wrapper that finalizes a `ResultAsync` exactly once. */
 export class DisposableResultAsync<T, E> implements PromiseLike<Result<T, E>>, AsyncDisposable {
   private readonly innerPromise: Promise<Result<T, E>>
   private readonly finalizer: (value: unknown, error: unknown) => void | Promise<void>
@@ -2996,6 +3000,7 @@ registerResultAsyncFactory(
   (promise) => new ResultAsync(promise as Promise<Result<unknown, unknown>>),
 )
 
+/** `ResultAsync` convention that restricts the error channel to real `Error` instances. */
 export type StrictResultAsync<T, E extends Error = Error> = ResultAsync<T, E>
 
 /**

--- a/packages/resultar/src/result.ts
+++ b/packages/resultar/src/result.ts
@@ -228,6 +228,7 @@ interface Resultable<T, E> {
   _unsafeUnwrapErr: (config?: ErrorConfig) => E
 }
 
+/** Operations shared by the Ok and Err variants of `Result<T, E>`. */
 export interface ResultOperations<T, E> {
   /**
    * Narrows this result to the Ok variant.
@@ -418,6 +419,7 @@ export interface ResultOperations<T, E> {
   safeUnwrap: () => Generator<Result<never, E>, T>
 }
 
+/** Successful `Result` variant carrying a value of type `T`. */
 export interface OkResult<T, E> extends ResultOperations<T, E> {
   /**
    * Ok value carried by this result.
@@ -425,6 +427,7 @@ export interface OkResult<T, E> extends ResultOperations<T, E> {
   readonly value: T
 }
 
+/** Failed `Result` variant carrying an error of type `E`. */
 export interface ErrResult<T, E> extends ResultOperations<T, E> {
   /**
    * Err value carried by this result.
@@ -432,7 +435,10 @@ export interface ErrResult<T, E> extends ResultOperations<T, E> {
   readonly error: E
 }
 
+/** Success-or-failure value with explicit Ok and Err channels. */
 export type Result<T, E> = OkResult<T, E> | ErrResult<T, E>
+
+/** `Result` convention that restricts the error channel to real `Error` instances. */
 export type StrictResult<T, E extends Error = Error> = Result<T, E>
 
 /**
@@ -453,6 +459,7 @@ export interface TryResultOptions<T, E = unknown> {
   readonly catch?: (e: unknown) => E
 }
 
+/** Object-form synchronous generator workflow accepted by `safeTry`. */
 export interface SafeTryOptions<
   YieldErr extends Result<never, unknown>,
   GeneratorReturnResult extends Result<unknown, unknown>,
@@ -470,6 +477,7 @@ export interface SafeTryOptions<
   readonly catch?: (e: unknown) => CatchErr
 }
 
+/** Object-form asynchronous generator workflow accepted by `safeTry`. */
 export interface SafeTryAsyncOptions<
   YieldErr extends Result<never, unknown>,
   GeneratorReturnResult extends Result<unknown, unknown>,
@@ -1356,6 +1364,7 @@ class ResultNamespace {
   }
 }
 
+/** Static helpers for creating, combining, and iterating over Result values. */
 export const Result: ResultStatic = ResultNamespace
 
 abstract class ResultVariant<T, E> extends Pipeable {

--- a/packages/resultar/src/tagged-error.ts
+++ b/packages/resultar/src/tagged-error.ts
@@ -119,6 +119,7 @@ type TaggedErrorConstructorArgs<Template extends string> = [
   ? [props?: { readonly cause?: unknown }]
   : [props: ConstructorProps<Template>]
 
+/** Configuration used to create a tagged `Error` class. */
 export interface TaggedErrorOptions<
   Tag extends string,
   MessageTemplate extends string,


### PR DESCRIPTION
## Summary

- add JSR-compatible module and exported-symbol documentation across all five Resultar packages
- document more than 80% of each package's public symbols without changing runtime behavior
- add patch changesets so JSR can evaluate fresh published artifacts
- retain GitHub Actions OIDC publishing for verifiable provenance

## Why

JSR scores the currently published package artifacts. The existing releases did not expose enough source-level symbol documentation for JSR, so the request adapters reported 0% documented exports. Fresh CI-published patch releases are also needed for JSR to reevaluate provenance.

JSR package descriptions and runtime compatibility settings have been updated separately in the registry UI.

## Release impact

The Changesets release workflow will prepare patch releases for:

- `resultar`
- `resultar-check`
- `resultar-request`
- `resultar-request-typebox`
- `resultar-request-zod`

After this PR is merged, merge the generated Changesets version PR to publish the new npm and JSR releases through GitHub Actions.

## Validation

- `pnpm run check`
- `pnpm run test` — 545 tests passed
- `pnpm run smoke:package`
- `pnpm run test:examples`
- JSR dry-run for all five packages
- Deno documentation inspection for module and exported-symbol coverage
- `pnpm changeset status`
- `git diff --check`

No runtime API or behavior changes are included.
